### PR TITLE
Caching wrapper around scoring/threshold based filters

### DIFF
--- a/col.py
+++ b/col.py
@@ -10,8 +10,7 @@ from typing import Optional, TypeVar, List
 from functools import wraps
 
 
-queue = SimpleQueue()
-
+queue = SimpleQueue() # type: SimpleQueue[list[bytes]]
 
 T = TypeVar("T")
 
@@ -21,59 +20,56 @@ def none_throws(optional: Optional[T], message: str = "Unexpected `None`") -> T:
     return optional
 
 
-def exit_on_throw(fn):
-	@wraps(fn)
-	def wrapper(*args, **kwargs):
-		try:
-			return fn(*args, **kwargs)
-		except:
-			print_exc(file=sys.stderr)
-			os.kill(os.getpid(), signal.SIGKILL)
-	return wrapper
-
-
 def split(column, queue, fin, fout):
-	for line in fin:
-		fields = line.rstrip(b'\n').split(b'\t')
-		queue.put(fields[:column] + fields[(column+1):])
-		fout.write(fields[column] + b'\n')
-	queue.put(None) # End indicator
-	fout.close()
-
+	try:
+		for line in fin:
+			fields = line.rstrip(b'\n').split(b'\t')
+			field = fields[column] # Doing column selection first so that if this fails, we haven't already written it to the queue
+			queue.put(fields[:column] + fields[(column+1):])
+			fout.write(field + b'\n')
+		fout.close()
+	except BrokenPipeError:
+		pass
+	finally:
+		queue.put(None) # End indicator
+		fin.close()
 
 def merge(column, queue, fin, fout):
-	for field in fin:
-		fields = queue.get()
-		if fields is None:
-			raise RuntimeError('Subprcess produced more lines of output than it was given.')
-		fout.write(b'\t'.join(fields[:column] + [field.rstrip(b'\n')] + fields[column:]) + b'\n')
-	if queue.get() is not None:
-		raise RuntimeError('Subprocess produced fewer lines than it was given.')
-	fout.close()
+	try:
+		for field in fin:
+			fields = queue.get()
+			if fields is None:
+				raise RuntimeError('Subprcess produced more lines of output than it was given.')
+			fout.write(b'\t'.join(fields[:column] + [field.rstrip(b'\n')] + fields[column:]) + b'\n')
+		if queue.get() is not None:
+			raise RuntimeError('Subprocess produced fewer lines than it was given.')
+		fout.close()
+	except BrokenPipeError:
+		pass
+	finally:
+		fin.close()
 
 
-try:
+if __name__ == '__main__':
 	column = int(sys.argv[1])
 
 	child = Popen(sys.argv[2:], stdin=PIPE, stdout=PIPE)
 
-	feeder = Thread(target=exit_on_throw(split), args=[column, queue, sys.stdin.buffer, none_throws(child).stdin])
-	feeder.start()
+	try:
+		feeder = Thread(target=split, args=[column, queue, sys.stdin.buffer, none_throws(child).stdin])
+		feeder.start()
 
-	consumer = Thread(target=exit_on_throw(merge), args=[column, queue, none_throws(child).stdout, sys.stdout.buffer])
-	consumer.start()
+		consumer = Thread(target=merge, args=[column, queue, none_throws(child).stdout, sys.stdout.buffer])
+		consumer.start()
 
-	retval = child.wait()
-
-	feeder.join()
-	consumer.join()
-
-	sys.exit(retval)
-except SystemExit:
-	pass
-except FileNotFoundError as e:
-	print(e, file=sys.stderr)
-	sys.exit(2)
-except:
-	print_exc(file=sys.stderr)
-	sys.exit(127)
+		feeder.join()
+		consumer.join()
+	except:
+		none_throws(child.stdin).close()
+		raise
+	finally:
+		sys.stderr.close()
+		# Whatever happens, make sure the child stops first otherwise we might
+		# end up with a zombie
+		retval = child.wait()
+		sys.exit(retval)

--- a/filters/laser_similarity.json
+++ b/filters/laser_similarity.json
@@ -21,5 +21,5 @@
             "help": "Two-letter target language code (ISO 639-1)"
         }
     },
-    "command": "../threshold.py --cache $TMPDIR/laser.$(echo \"$SRCLANG $TGTLANG\" | cksum | cut -d' ' -f1).dbm $THRESHOLD ./laser_similarity.py --scores --src-lang $SRCLANG --tgt-lang $TGTLANG"
+    "command": "../threshold.py --cache $TMPDIR/laser.$(echo \"$SRCLANG:$TGTLANG\" | cksum | cut -d' ' -f1).dbm $THRESHOLD ./laser_similarity.py --scores --src-lang $SRCLANG --tgt-lang $TGTLANG"
 }

--- a/filters/laser_similarity.json
+++ b/filters/laser_similarity.json
@@ -21,5 +21,5 @@
             "help": "Two-letter target language code (ISO 639-1)"
         }
     },
-    "command": "../threshold.py --cache test.bin $THRESHOLD ./laser_similarity.py --scores --src-lang $SRCLANG --tgt-lang $TGTLANG"
+    "command": "../threshold.py --cache $TMPDIR/laser.$(echo \"$SRCLANG $TGTLANG\" | cksum | cut -d' ' -f1).dbm $THRESHOLD ./laser_similarity.py --scores --src-lang $SRCLANG --tgt-lang $TGTLANG"
 }

--- a/filters/laser_similarity.json
+++ b/filters/laser_similarity.json
@@ -8,12 +8,6 @@
             "default": 0.5,
             "help": "Minimum accepted LASER score."
         },
-        "BATCHSIZE": {
-            "type": "int",
-            "required": false,
-            "default": 32,
-            "help": "LASER batch size"
-        },
         "SRCLANG": {
             "type": "str",
             "required": true,
@@ -27,5 +21,5 @@
             "help": "Two-letter target language code (ISO 639-1)"
         }
     },
-    "command": "./laser_similarity.py --threshold $THRESHOLD --batch-size $BATCHSIZE --src-lang $SRCLANG --tgt-lang $TGTLANG"
+    "command": "../threshold.py --cache test.bin $THRESHOLD ./laser_similarity.py --scores --src-lang $SRCLANG --tgt-lang $TGTLANG"
 }

--- a/filters/laser_similarity.py
+++ b/filters/laser_similarity.py
@@ -40,7 +40,7 @@ def main():
 
     for batch in chunked(sys.stdin, args.batch_size):
         # TODO error checking of column count?
-        scores = _compute_similarity(laser, [line.split("\t") for line in batch], args.src_lang, args.tgt_lang)
+        scores = _compute_similarity(laser, [tuple(line.split("\t")[:2]) for line in batch], args.src_lang, args.tgt_lang)
 
         if args.scores:
             for score in scores:

--- a/filters/laser_similarity.py
+++ b/filters/laser_similarity.py
@@ -23,22 +23,32 @@ def _cosine_sim(emb1: np.ndarray, emb2: np.ndarray) -> np.ndarray:
 def main():
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
                                      description="Filter a parallel dataset using LASER.")
-    parser.add_argument("--threshold", type=float, default=0.5, help="Minimum accepted LASER score.")
     parser.add_argument("--batch-size", type=int, default=32, help="LASER batch size")
     parser.add_argument("--src-lang", type=str, required=True, help="Two-letter source language code (ISO 639-1)")
     parser.add_argument("--tgt-lang", type=str, required=True, help="Two-letter target language code (ISO 639-1)")
+    
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--threshold", type=float, help="Minimum accepted LASER score.")
+    group.add_argument("--scores", action="store_true", help="Print scores instead of lines")
 
     args = parser.parse_args()
-    
+
+    if not args.scores and args.threshold is None:
+        print("Either use --threshold or --scores")
+
     laser = Laser()
 
     for batch in chunked(sys.stdin, args.batch_size):
         # TODO error checking of column count?
         scores = _compute_similarity(laser, [line.split("\t") for line in batch], args.src_lang, args.tgt_lang)
 
-        for line, score in zip(batch, scores):
-            if score >= args.threshold:
-                sys.stdout.write(line)
+        if args.scores:
+            for score in scores:
+                print(score, file=sys.stdout)
+        else:
+            for line, score in zip(batch, scores):
+                if score >= args.threshold:
+                    sys.stdout.write(line)
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,3 +38,4 @@ uvloop==0.16.0
 watchgod==0.8.2
 wcwidth==0.2.5
 websockets==10.3
+xxhash==3.0.0

--- a/run.py
+++ b/run.py
@@ -231,10 +231,9 @@ def main(argv):
         print('[run.py] KeyboardInterrupt', file=sys.stderr)
         pass
 
-    # Wait for all the processes that are still alive
+    # Wait for all the processes to prevent zombies
     for child in children:
         if child.returncode is None:
-            print(f"Waiting for {child!r}", file=sys.stderr)
             child.wait()
 
     # Wait for the babysitters to exit, which happens when their process stops

--- a/threshold.py
+++ b/threshold.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+import sys
+import os
+import signal
+import argparse
+import pickle
+from pyhash import murmur3_32
+from traceback import print_exc
+from subprocess import Popen, PIPE
+from threading import Thread
+from queue import SimpleQueue
+from typing import Callable, Optional, Type, TypeVar, Dict
+from functools import wraps
+
+
+class Entry:
+	"""Cache entry. Only an object with single property so we can easily update
+	it by reference, really.
+	"""
+	__slots__ = ['score']
+	score: Optional[float]
+
+	def __init__(self):
+		self.score = None
+
+
+T = TypeVar("T")
+
+
+def none_throws(optional: Optional[T], message: str = "Unexpected `None`") -> T:
+	"""Runtime cast of `Optional[T]` into `T`. Will raise an AssertionError if
+	the argument was indeed `None`.
+	"""
+	if optional is None:
+		raise ValueError(message)
+	return optional
+
+
+def exit_on_throw(fn):
+	"""Wraps thread main function so that an exception thrown in the thread
+	will terminate the entire process.
+	"""
+	@wraps(fn)
+	def wrapper(*args, **kwargs):
+		try:
+			return fn(*args, **kwargs)
+		except:
+			print_exc(file=sys.stderr)
+			os.kill(os.getpid(), signal.SIGKILL)
+	return wrapper
+
+
+def feed_child(queue, fin, fchild, cache):
+	"""Thread that reads each line from stream `fin`, and will put its score
+	`Entry` onto queue `queue`. If a line is a duplicate, it will use the entry
+	from the previous occurrence. If a line is new, it will also feed it to
+	child process `fchild` so a score can be calculated. Because the order of
+	the queue and the order of feeding fchild are the same, the
+	`threshold_scores` thread will know how to link them back together.
+	"""
+	derive_key = murmur3_32()
+
+	for line in fin:
+		key = derive_key(line)
+		# if key not in cache, we've never seen the sentence
+		if key not in cache:
+			fchild.write(line)
+			cache[key] = Entry()
+
+		queue.put((line, cache[key]))
+	queue.put(None) # End indicator
+	fchild.close()
+
+
+def threshold_scores(queue, fchild, fout, threshold):
+	"""Thread that reads the queue and, depending on the threshold, will write
+	the line to output. It will also read any missing scores from the child
+	`fchild`. Because this is the only thread reading & writing to Entry objects
+	no locks are necessary.
+	"""
+	while True:
+		item = queue.get()
+
+		# Poison
+		if item is None:
+			break
+
+		# If no score yet, get it from the child
+		if item[1].score is None:
+			item[1].score = float(fchild.readline())
+
+		# Only print the actual line if threshold is met
+		if item[1].score >= threshold:
+			fout.write(item[0])
+	
+	# TODO: test somehow that child has stopped producing? Reading from `fchild`
+	# should at this point return EOF since its stdin is already closed.
+	fout.close()
+
+try:
+	parser = argparse.ArgumentParser()
+	parser.add_argument('--cache', '-c', type=str)
+	parser.add_argument('threshold', type=float)
+	parser.add_argument('scorer', type=str, nargs='+')
+
+	args, scorer_args = parser.parse_known_args()
+
+	# TODO: Make this Popen call only necessary if there was any need for it,
+	# i.e. not all sentences could be scored by just the cache. I'm tempted to
+	# add yet another wrapper program that only starts the process once input
+	# is readable from stdin and then just re-attaches stdin to the child? Bit
+	# like how inetd works.
+	child = Popen(args.scorer + scorer_args, stdin=PIPE, stdout=PIPE)
+
+	cache: Dict[int,Entry] = dict()
+
+	queue = SimpleQueue() # type: SimpleQueue[tuple[bytes,Entry]]
+
+	if args.cache and os.path.exists(args.cache):
+		with open(args.cache, 'rb') as fin:
+			cache = pickle.load(fin)
+
+	# Reads stdin, writes it to queue, and possibly to child for scoring.
+	feeder = Thread(target=exit_on_throw(feed_child), args=[queue, sys.stdin.buffer, child.stdin, cache])
+	feeder.start()
+
+	# Reads queue, writes to stdout, reading scores from child if necessary.
+	consumer = Thread(target=exit_on_throw(threshold_scores), args=[queue, child.stdout, sys.stdout.buffer, args.threshold])
+	consumer.start()
+
+	# Feeder will be done at this point
+	feeder.join()
+
+	# Consumer will be done once it read the last None from the queue.
+	consumer.join()
+
+	# Feeder will close child.stdin when all input is processed, which should
+	# cause child to terminate.
+	retval = child.wait()
+
+	# Save cache to disk for the next call
+	# (TODO: file lock?)
+	# TODO: make cache dependant on child cli args!
+	if args.cache:
+		with open(args.cache, 'wb') as fout:
+			pickle.dump(cache, fout)
+
+	sys.exit(retval)
+except SystemExit:
+	pass
+except FileNotFoundError as e:
+	print(e, file=sys.stderr)
+	sys.exit(2)
+except:
+	print_exc(file=sys.stderr)
+	sys.exit(127)


### PR DESCRIPTION
Initial implementation of the idea from https://github.com/jelmervdl/empty-train/issues/29.

Basically it rewrites the more expensive score-based filtering filters into something that just generates a score. Then the `threshold.py` program uses this score to determine which lines to filter.

The upside of all this is that the scores can be cached based on the line hash! So especially for the sample which is constantly being re-filtered, this should speed things up after the initial run.

Maybe in the future empty-train could show you the scores as an extra column. It also makes the filtering programs a bit simpler: they don't need to do the thresholding anymore. It will also be easier to add filters that filter rows based on (the score of) a single column.

Edit credit where credit's due: this was partially inspired by how [OpusFilter](https://github.com/Helsinki-NLP/OpusFilter) filters work: they each implement a score & and a threshold function. See https://github.com/Helsinki-NLP/OpusFilter/blob/develop/opusfilter/filters.py.