### PR TITLE
Categories

### DIFF
--- a/categories.py
+++ b/categories.py
@@ -4,7 +4,7 @@ from fastapi import FastAPI
 from pydantic import BaseModel, parse_obj_as, validator
 from typing import List, Dict, TextIO, cast
 
-from config import CATEGORIES_PATH, DATA_PATH
+from config import CATEGORIES_PATH, DATA_PATH, DEFAULT_CATEGORIES
 
 
 class Category(BaseModel):
@@ -46,7 +46,7 @@ def get_mapping() -> CategoryMapping:
 		with open(CATEGORIES_PATH, 'r') as fh:
 			return read_categories(fh)
 	else:
-		return CategoryMapping(categories=[], mapping=dict())
+		return CategoryMapping(categories=DEFAULT_CATEGORIES, mapping=dict())
 
 @app.put('/')
 def update_categories(body: CategoryMapping):

--- a/categories.py
+++ b/categories.py
@@ -1,0 +1,54 @@
+import os
+import json
+from fastapi import FastAPI
+from pydantic import BaseModel, parse_obj_as, validator
+from typing import List, Dict, TextIO, cast
+
+from config import CATEGORIES_PATH, DATA_PATH
+
+
+class Category(BaseModel):
+	name: str
+
+	@validator('name')
+	def name_must_not_be_empty(cls, value):
+		assert len(value.strip()) > 0, 'must not be empty'
+		return value.strip()
+
+
+class CategoryMapping(BaseModel):
+	categories: List[Category]
+	mapping: Dict[str,List[str]]
+
+	@validator('categories')
+	def categories_must_be_unique(cls, value):
+		assert len(set(category.name.strip() for category in value)) == len(value), 'categories must have unique names'
+		return value
+
+	@validator('mapping')
+	def mapping_must_only_contain_categories(cls, value, values, **kwargs):
+		assert len(set(value.keys()) - set(category.name.strip() for category in values.get('categories', ''))) == 0, 'mapping must only contain keys that are defined in `categories`'
+		return value
+
+
+def read_categories(fh: TextIO):
+	return parse_obj_as(CategoryMapping, json.load(fh))
+
+def write_categories(mapping: CategoryMapping, fh: TextIO):
+	json.dump(mapping.dict(), fh, indent=2)
+
+
+app = FastAPI()
+
+@app.get('/')
+def get_mapping() -> CategoryMapping:
+	if os.path.exists(CATEGORIES_PATH):
+		with open(CATEGORIES_PATH, 'r') as fh:
+			return read_categories(fh)
+	else:
+		return CategoryMapping(categories=[], mapping=dict())
+
+@app.put('/')
+def update_categories(body: CategoryMapping):
+	with open(CATEGORIES_PATH, 'w') as fh:
+		write_categories(body, fh)

--- a/config.py
+++ b/config.py
@@ -7,6 +7,12 @@ DATA_PATH = os.getenv('DATA_PATH', 'data/train-parts/*.*.gz')
 # which.
 CATEGORIES_PATH = os.path.join(os.path.dirname(DATA_PATH), 'categories.json')
 
+DEFAULT_CATEGORIES = [
+	{'name': 'clean'},
+	{'name': 'medium'},
+	{'name': 'dirty'}
+]
+
 # TODO: Derive this from DATA_PATH but in such a way that mtdata actually writes
 # the files to the correct folder?
 DOWNLOAD_PATH = 'data'

--- a/config.py
+++ b/config.py
@@ -1,0 +1,30 @@
+import os
+
+# Path to data files. Expects to find files named `$DATASET.$LANG.gz`.
+DATA_PATH = os.getenv('DATA_PATH', 'data/train-parts/*.*.gz')
+
+# Path to the file that defines the categories, and which dataset belongs to 
+# which.
+CATEGORIES_PATH = os.path.join(os.path.dirname(DATA_PATH), 'categories.json')
+
+# TODO: Derive this from DATA_PATH but in such a way that mtdata actually writes
+# the files to the correct folder?
+DOWNLOAD_PATH = 'data'
+
+# glob expression that looks for the filter files. Unfortunately you can't use
+# commas and {} in this expression. TODO: fix that, you should be able to name
+# multiple paths.
+FILTER_PATH = 'filters/*.json'
+
+# col.py is used to apply a monolingual filter to a bilingual dataset. Needs
+# to be absolute since filters can run from different cwds.
+COL_PY = os.path.abspath('./col.py')
+
+# Program used to derive a sample from the dataset. Will be called like
+# `./sample.py -n $SAMPLE_SIZE ...file-per-lang.gz`. Absolute because filters
+# can specify their own `cwd`.
+SAMPLE_PY = os.path.abspath('./sample.py')
+
+# Size of each of the three sections (head, random sample of middle, tail) of
+# the dataset sample that we operate on.
+SAMPLE_SIZE = int(os.getenv('SAMPLE_SIZE', '1000'))

--- a/download.py
+++ b/download.py
@@ -21,10 +21,7 @@ from mtdata.iso.bcp47 import bcp47, BCP47Tag
 from pydantic import BaseModel
 from fastapi import FastAPI, HTTPException
 
-
-DATA_PATH = os.getenv('DATA_PATH', 'data/train-parts/*.*.gz')
-
-DOWNLOAD_PATH = 'data'
+from config import DATA_PATH, DOWNLOAD_PATH
 
 
 class EntryRef(BaseModel):

--- a/frontend/src/components/CategoryPicker.vue
+++ b/frontend/src/components/CategoryPicker.vue
@@ -1,0 +1,109 @@
+<script setup>
+import { ref, computed, watch, reactive } from 'vue';
+import {
+	getCategories,
+	getCategoriesForDataset,
+	setCategoriesForDataset
+} from '../store/categories.js';
+
+const position = reactive({
+	top: '0px',
+	left: '0px'
+});
+
+const isOpen = ref(false);
+
+const currentDataset = ref(null);
+
+let modifiedCategories = null;
+
+// Make categories default to the ones from the store, unless we've modified
+// them already through the UI.
+const categories = computed({
+	get() {
+		if (currentDataset.value === null)
+			return null;
+
+		if (modifiedCategories !== null)
+			return modifiedCategories;
+
+		return getCategoriesForDataset(currentDataset.value);
+	},
+	set(value) {
+		modifiedCategories = value;
+	}
+});
+
+// When the dataset changes, also reset the changes to the categories we made.
+watch(currentDataset, function (current, old) {
+		if (current?.name !== old?.name)
+			modifiedCategories = null;
+	},
+	{deep: true} // TODO: necessary?
+);
+
+function apply() {
+	console.assert(currentDataset.value !== null);
+
+	if (modifiedCategories !== null) {
+		setCategoriesForDataset(modifiedCategories, currentDataset.value);
+		modifiedCategories = null;
+	}
+
+	hide();
+}
+
+async function showForDataset(dataset, event) {
+	currentDataset.value = dataset;
+
+	if (event) {
+		const rect = event.target.getBoundingClientRect();
+		Object.assign(position, {
+			top: `${rect.bottom}px`,
+			left: `${rect.left}px`
+		});
+	}
+}
+
+function hide() {
+	currentDataset.value = null;
+}
+
+defineExpose({
+	showForDataset,
+	hide
+});
+
+</script>
+
+<template>
+	<Teleport to="body">
+		<div ref="element" v-if="currentDataset !== null" class="popup" :style="position">
+			<header>
+				Set categories
+			</header>
+			<ol>
+				<li v-for="category in getCategories()" :key="category.name">
+					<label>
+						<input type="checkbox" v-model="categories" :value="category">
+						{{ category.name }}
+					</label>
+				</li>
+			</ol>
+			<footer>
+				<button @click="hide">Cancel</button>
+				<button @click="apply">Apply</button>
+			</footer>
+		</div>
+	</Teleport>
+</template>
+
+<style scoped>
+.popup {
+	position: fixed;
+	top: 0;
+	left: 0;
+	background: white;
+	border: 1px solid #ccc;
+}
+</style>

--- a/frontend/src/components/CategoryPicker.vue
+++ b/frontend/src/components/CategoryPicker.vue
@@ -82,7 +82,7 @@ defineExpose({
 			<header>
 				Set categories
 			</header>
-			<ol>
+			<ol class="category-list">
 				<li v-for="category in getCategories()" :key="category.name">
 					<label>
 						<input type="checkbox" v-model="categories" :value="category">
@@ -105,5 +105,32 @@ defineExpose({
 	left: 0;
 	background: white;
 	border: 1px solid #ccc;
+	min-width: 200px;
+	box-shadow: 2px 2px 8px rgba(0, 0, 0, 0.5);
 }
+
+.popup > *:not(:last-child) {
+	border-bottom: 1px solid #ccc;
+}
+
+footer {
+	text-align: right;
+}
+
+footer > *:not(:last-child) {
+	margin-right: 0.5em;
+}
+
+.category-list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+}
+
+header,
+footer,
+.category-list label {
+	padding: 0.5em;
+}
+
 </style>

--- a/frontend/src/components/FilterEditor.vue
+++ b/frontend/src/components/FilterEditor.vue
@@ -9,7 +9,10 @@ import LoadingIndicator from './LoadingIndicator.vue';
 import {stream} from '../stream.js';
 import { getFilters } from '../store/filters.js';
 import { getFilterSteps, saveFilterSteps, filterStepsModified } from '../store/filtersteps.js';
+import { getCategoriesForDataset } from '../store/categories.js';
 import { formatNumberSuffix } from '../format.js';
+import CategoryPicker from '../components/CategoryPicker.vue';
+
 
 const multiDragKey = navigator.platform.match(/^(Mac|iPhone$)/) ? 'Meta' : 'Control';
 
@@ -211,7 +214,8 @@ export default {
 	components: {
 		draggable,
 		InlineDiff,
-		LoadingIndicator
+		LoadingIndicator,
+		CategoryPicker
 	},
 
 	methods: {
@@ -274,6 +278,7 @@ export default {
 		},
 		stamp,
 		formatNumberSuffix,
+		getCategoriesForDataset,
 	}
 };
 </script>
@@ -288,6 +293,13 @@ export default {
 			<input type="checkbox" v-model="displayAsRows">
 			Display as rows
 		</label>
+
+		<button @click="$refs.categoryPicker.showForDataset(dataset, $event)">Edit categories</button>
+		<ul class="dataset-categories">
+			<li class="category" v-for="category in getCategoriesForDataset(dataset)" :key="category.name">{{ category.name }}</li>
+		</ul>
+
+		<CategoryPicker ref="categoryPicker"></CategoryPicker>
 
 		<button v-on:click="saveFilterSteps" v-bind:disabled="!filterStepsChangedSinceLastSave">Save filtering steps</button>
 
@@ -382,7 +394,7 @@ export default {
 								<option v-for="lang in languages">{{lang}}</option>
 							</select>
 						</div>
-						<div v-for="(parameter, name) in filterDefinition(filterStep).parameters">
+						<div v-for="(parameter, name) in filterDefinition(filterStep)?.parameters || {}">
 							<label v-bind:for="`step-${i}-${name}`">{{ name }}</label>
 							<select v-if="parameter.type == 'str' && parameter.allowed_values" v-model="filterStep.parameters[name]" v-bind:id="`step-${i}-${name}`">
 								<option v-for="value in parameter.allowed_values" v-bind:value="value">{{value}}</option>
@@ -414,6 +426,8 @@ export default {
 </template>
 
 <style scoped>
+@import '../css/categories.css';
+
 .filter-output {
 	display: flex;
 	flex-direction: column;
@@ -646,4 +660,15 @@ input[type=checkbox] {
 .property-list > * > input[type=checkbox] {
 	flex-basis: 1em;
 }
+
+.dataset-categories {
+	display: inline;
+	list-style: none;
+	padding: 0;
+}
+
+.dataset-categories li {
+	display: inline;
+}
+
 </style>

--- a/frontend/src/components/FilterEditor.vue
+++ b/frontend/src/components/FilterEditor.vue
@@ -9,6 +9,7 @@ import LoadingIndicator from './LoadingIndicator.vue';
 import {stream} from '../stream.js';
 import { getFilters } from '../store/filters.js';
 import { getFilterSteps, saveFilterSteps, filterStepsModified } from '../store/filtersteps.js';
+import { formatNumberSuffix } from '../format.js';
 
 const multiDragKey = navigator.platform.match(/^(Mac|iPhone$)/) ? 'Meta' : 'Control';
 
@@ -103,19 +104,6 @@ function stamp(obj) {
 	if (!stamps.has(obj))
 		stamps.set(obj, ++serial);
 	return stamps.get(obj);
-}
-
-function formatNumberSuffix(n) {
-	let suffix = 'th';
-
-	if (n % 10 === 1 && n % 100 !== 11)
-		suffix = 'st';
-	else if (n % 10 === 2 && n % 100 !== 12)
-		suffix = 'nd';
-	else if (n % 10 === 3 && n % 100 !== 13)
-		suffix = 'rd';
-
-	return `${n}${suffix}`;
 }
 
 const shared = {

--- a/frontend/src/css/categories.css
+++ b/frontend/src/css/categories.css
@@ -1,0 +1,10 @@
+.category {
+	display: inline-block;
+	margin: 0 0.125em;
+	padding: 0.125em 0.25em;
+	background: #ccc;
+	border-radius: 2px;
+	font-size: 0.8em;
+	line-height: 1;
+	vertical-align: baseline;
+}

--- a/frontend/src/format.js
+++ b/frontend/src/format.js
@@ -1,0 +1,17 @@
+export function formatNumberSuffix(n) {
+	let suffix = 'th';
+
+	if (n % 10 === 1 && n % 100 !== 11)
+		suffix = 'st';
+	else if (n % 10 === 2 && n % 100 !== 12)
+		suffix = 'nd';
+	else if (n % 10 === 3 && n % 100 !== 13)
+		suffix = 'rd';
+
+	return `${n}${suffix}`;
+}
+
+export function formatSize(size) {
+	const i = size == 0 ? 0 : Math.floor(Math.log(size) / Math.log(1024));
+	return (size / Math.pow(1024, i)).toFixed(2) + ' ' + ['B', 'kB', 'MB', 'GB', 'TB'][i];
+}

--- a/frontend/src/store/categories.js
+++ b/frontend/src/store/categories.js
@@ -1,0 +1,33 @@
+import {reactive} from 'vue';
+
+const data = reactive({
+	categories: [],
+	mapping: {}
+});
+
+async function fetchCategories() {
+	const response = await fetch('/api/categories/');
+	return await response.json();
+}
+
+let request = null;
+
+export function getCategories() {
+	if (!request)
+		request = fetchCategories().then(remote => Object.assign(data, remote));
+
+	return data
+}
+
+export function getCategoriesForDataset(dataset) {
+	const data = getCategories();
+
+	// Look through all mappings, and return the category objects if the dataset
+	// name is mentioned in the mapping section for it.
+	return Object.entries(data.mapping).reduce((acc, [name, datasets]) => {
+		if (datasets.includes(dataset.name))
+			return [...acc, data.categories.find(category => category.name == name)]
+		else
+			return acc
+	}, []);
+}

--- a/frontend/src/store/categories.js
+++ b/frontend/src/store/categories.js
@@ -58,18 +58,26 @@ export function setCategoriesForDataset(categories, dataset) {
 	// the categories. I made a stupid server side API (but the file format is
 	// nicely human readable now at least. But I could have solved this in Python!)
 	getCategories().forEach(({name}) => {
+		// If this category should have the dataset
 		if (names.has(name)) {
+			// … and there is no mapping for it yet
 			if (!(name in data.mapping))
 				data.mapping[name] = [dataset.name]
-			else
+			// … and there is a mapping for it, but this dataset is not in it
+			else if (!data.mapping[name].includes(dataset.name))
 				data.mapping[name].push(dataset.name)
-		} else {
+		} 
+		// else if this category should not have this dataset
+		else {
+			// … and there is a mapping for this category
 			if (name in data.mapping) {
 				const index = data.mapping[name].indexOf(dataset.name);
+				// … and this dataset is in that mapping, remove it.
 				if (index !== -1)
 					data.mapping[name].splice(index, 1);
 			}
 		}
 	})
+
 	pushCategories();
 }

--- a/frontend/src/views/AddDatasetView.vue
+++ b/frontend/src/views/AddDatasetView.vue
@@ -1,6 +1,7 @@
 <script setup>
 import {ref, reactive, computed, watch, onMounted} from 'vue';
 import { Interval } from '../interval.js';
+import { formatSize } from '../format.js';
 
 const loading = ref(0);
 
@@ -150,11 +151,6 @@ async function requestDownloadSelection(datasets) {
 		},
 		body: JSON.stringify(datasets.map(({id}) => ({id})))
 	});
-}
-
-function formatSize(size) {
-	const i = size == 0 ? 0 : Math.floor(Math.log(size) / Math.log(1024));
-	return (size / Math.pow(1024, i)).toFixed(2) + ' ' + ['B', 'kB', 'MB', 'GB', 'TB'][i];
 }
 
 </script>

--- a/frontend/src/views/ListDatasetsView.vue
+++ b/frontend/src/views/ListDatasetsView.vue
@@ -49,6 +49,8 @@ const categoryPicker = ref(); // Element
 </template>
 
 <style>
+@import '../css/categories.css';
+
 .dataset-list {
 	flex: 1;
 	overflow: auto;
@@ -62,14 +64,4 @@ const categoryPicker = ref(); // Element
 	background: #eef;
 }
 
-.category {
-	display: inline-block;
-	margin: 0 0.125em;
-	padding: 0.125em 0.25em;
-	background: #ccc;
-	border-radius: 2px;
-	font-size: 0.8em;
-	line-height: 1;
-	vertical-align: baseline;
-}
 </style>

--- a/frontend/src/views/ListDatasetsView.vue
+++ b/frontend/src/views/ListDatasetsView.vue
@@ -3,6 +3,7 @@ import { ref } from 'vue';
 import { RouterLink } from 'vue-router';
 import { getDatasets } from '../store/datasets.js';
 import { getFilterSteps } from '../store/filtersteps.js';
+import { getCategoriesForDataset } from '../store/categories.js';
 
 function languages(dataset) {
 	return Object.keys(dataset?.columns || {});
@@ -13,11 +14,24 @@ function languages(dataset) {
 <template>
 	<div class="dataset-list">
 		<table>
-			<tr v-for="dataset in getDatasets()" :key="dataset.id">
-				<td>{{ dataset.name }}</td>
-				<td>{{ languages(dataset).join(', ') }}</td>
-				<td><router-link :to="{name: 'edit-filters', params: {datasetName: dataset.name}}">Filters ({{ getFilterSteps(dataset).length }})</router-link></td>
-			</tr>
+			<thead>
+				<tr>
+					<th>Name</th>
+					<th>Languages</th>
+					<th>Categories</th>
+					<th>Filter steps</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr v-for="dataset in getDatasets()" :key="dataset.id">
+					<td>{{ dataset.name }}</td>
+					<td>{{ languages(dataset).join(', ') }}</td>
+					<td>
+						<span class="category" v-for="category in getCategoriesForDataset(dataset)" :key="category.name">{{ category.name }}</span>
+					</td>
+					<td><router-link :to="{name: 'edit-filters', params: {datasetName: dataset.name}}">Filters ({{ getFilterSteps(dataset).length }})</router-link></td>
+				</tr>
+			</tbody>
 			<tfoot>
 				<tr>
 					<td colspan="3">

--- a/frontend/src/views/ListDatasetsView.vue
+++ b/frontend/src/views/ListDatasetsView.vue
@@ -4,10 +4,13 @@ import { RouterLink } from 'vue-router';
 import { getDatasets } from '../store/datasets.js';
 import { getFilterSteps } from '../store/filtersteps.js';
 import { getCategoriesForDataset } from '../store/categories.js';
+import CategoryPicker from '../components/CategoryPicker.vue';
 
 function languages(dataset) {
 	return Object.keys(dataset?.columns || {});
 }
+
+const categoryPicker = ref(); // Element
 
 </script>
 
@@ -27,6 +30,7 @@ function languages(dataset) {
 					<td>{{ dataset.name }}</td>
 					<td>{{ languages(dataset).join(', ') }}</td>
 					<td>
+						<button @click="event => categoryPicker.showForDataset(dataset, event)">Edit</button>
 						<span class="category" v-for="category in getCategoriesForDataset(dataset)" :key="category.name">{{ category.name }}</span>
 					</td>
 					<td><router-link :to="{name: 'edit-filters', params: {datasetName: dataset.name}}">Filters ({{ getFilterSteps(dataset).length }})</router-link></td>
@@ -40,6 +44,7 @@ function languages(dataset) {
 				</tr>
 			</tfoot>
 		</table>
+		<CategoryPicker ref="categoryPicker"></CategoryPicker>
 	</div>
 </template>
 
@@ -55,5 +60,16 @@ function languages(dataset) {
 
 .dataset-list table tr:nth-child(2n) td {
 	background: #eef;
+}
+
+.category {
+	display: inline-block;
+	margin: 0 0.125em;
+	padding: 0.125em 0.25em;
+	background: #ccc;
+	border-radius: 2px;
+	font-size: 0.8em;
+	line-height: 1;
+	vertical-align: baseline;
 }
 </style>

--- a/main.py
+++ b/main.py
@@ -30,25 +30,12 @@ from pprint import pprint
 
 from datasets import list_datasets, Path
 from download import app as download_app
+from categories import app as categories_app
+from config import DATA_PATH, FILTER_PATH, COL_PY, SAMPLE_PY, SAMPLE_SIZE
 from sample import sample
 
 import mimetypes
 mimetypes.add_type('application/javascript', '.js')
-
-
-DATA_PATH = os.getenv('DATA_PATH', 'data/train-parts/*.*.gz')
-
-FILTER_PATH = 'filters/*.json'
-
-# col.py is used to apply a monolingual filter to a bilingual dataset. Needs
-# to be absolute since filters can run from different cwds.
-COL_PY = os.path.abspath('./col.py')
-
-SAMPLE_PY = os.path.abspath('./sample.py')
-
-# Size of each of the three sections (head, random sample of middle, tail) of
-# the dataset sample that we operate on.
-SAMPLE_SIZE = int(os.getenv('SAMPLE_SIZE', '1000'))
 
 
 class File(BaseModel):
@@ -406,6 +393,8 @@ def redirect_to_interface():
 app.mount('/frontend/', StaticFiles(directory='frontend/dist', html=True), name='static')
 
 app.mount('/api/download/', download_app)
+
+app.mount('/api/categories/', categories_app)
 
 def main_serve(args):
     import uvicorn


### PR DESCRIPTION
Implementation of #42 because I'm really missing it right now while looking at datasets in detail.

This adds some minimal UI and support for categorising datasets while you're looking at them. Categories are stored in a separate single json file so they should be pretty easy to use downstream when concatenating datasets for the trainer.

Right now you can add multiple categories to a single dataset. You can also define categories that are not yet assigned to any dataset. There's room for adding labels or colours to these categories in future iterations.

Not sure about the multiple categories per dataset. It gives you the freedom that _tags_ would give you. You don't need to use all the tags you assign to each dataset. But I imagine some future use case where you want to also tag datasets with domain specific tags that you can then choose to use during finetuning or something.

I also moved most of the configuration constants into a single file that can be included when needed.

TODO:
- [x] APIs to read/write category mappings
- [x] Add UI to overview for selecting categories
- [x] Add UI to dataset filter editor for selecting categories
- [ ] Add UI to define new categories (but editing the json in the file or through [the API docs](http://localhost:8000/api/categories/docs#/default/update_categories__put) also works for me now)