### PR TITLE
Trainer clean up

### DIFF
--- a/trainer/random.sh
+++ b/trainer/random.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-# $1 = seed, $2 = outputfile, $3 = inputfile(s)
-SEED="$1"
-shift
-
-OUTFILE="$1"
-shift
-
-cat "$@" | shuf --random-source=<(openssl enc -aes-256-ctr -pass pass:"$SEED" -nosalt </dev/zero 2>/dev/null) -o "$OUTFILE"

--- a/trainer/random.sh
+++ b/trainer/random.sh
@@ -1,3 +1,9 @@
 #!/usr/bin/env bash
-# $1 = seed, $2 = outputfile, $3 = inputfile
-shuf --random-source=<(openssl enc -aes-256-ctr -pass pass:"$1" -nosalt </dev/zero 2>/dev/null) -o $2 $3
+# $1 = seed, $2 = outputfile, $3 = inputfile(s)
+SEED="$1"
+shift
+
+OUTFILE="$1"
+shift
+
+cat "$@" | shuf --random-source=<(openssl enc -aes-256-ctr -pass pass:"$SEED" -nosalt </dev/zero 2>/dev/null) -o "$OUTFILE"

--- a/trainer/shuffle.py
+++ b/trainer/shuffle.py
@@ -139,6 +139,10 @@ class Reader(Iterable[bytes]):
 		self.filename = filename
 
 	def _read_gzip(self, filename:str) -> Iterable[bytes]:
+		"""Open gzipped files through gzip subprocess. It is faster than Python's
+		gzip submodule, and you get a bit of multiprocessing for free as the
+		external gzip process can decompress up to BUFSIZE while python is doing
+		other things."""
 		child = subprocess.Popen(['gzip', '-cd', filename], stdout=subprocess.PIPE, bufsize=BUFSIZE)
 		assert child.stdout is not None
 		yield from child.stdout

--- a/trainer/shuffle.py
+++ b/trainer/shuffle.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+import subprocess
+import sys
+import os
+from argparse import ArgumentParser, FileType
+from itertools import islice, chain
+from tempfile import mkstemp
+from typing import TypeVar, Iterable, List, Optional
+from queue import SimpleQueue
+from threading import Thread
+from dataclasses import dataclass
+from random import Random
+
+# Buffer size for reading files. Bufsize that Python assigns is generally too small?
+BUFSIZE=2**16
+
+T = TypeVar('T')
+
+def chunked(iterable: Iterable[T], chunk_size:int) -> Iterable[Iterable[T]]:
+	try:
+		it = iter(iterable)
+		while True:
+			has_next = next(it)
+			yield chain([has_next], islice(it, chunk_size - 1))
+	except StopIteration:
+		pass
+
+
+def split(fh: Iterable[bytes], lines:int, dir=None) -> Iterable[str]:
+	for chunk in chunked(fh, lines):
+		fd, name = mkstemp(dir=dir)
+		try:
+			with os.fdopen(fd, 'wb') as fh:
+				fh.writelines(chunk)
+			yield name
+		except:
+			os.unlink(name)
+			raise
+
+
+@dataclass(frozen=True)
+class ShuffleTask:
+	seed: float
+	filename: str
+
+
+def shuffle_chunk(queue:SimpleQueue[Optional[ShuffleTask]]):
+	while True:
+		task = queue.get()
+
+		if task is None:
+			break
+
+		random = Random(task.seed)
+
+		with open(task.filename, 'rb+', buffering=BUFSIZE) as fh:
+			lines = fh.readlines()
+			random.shuffle(lines)
+			fh.seek(0)
+			fh.writelines(lines)
+
+
+def shuffle(fin: Iterable[bytes], lines:int, *, seed: Optional[int] = None, threads: Optional[int] = os.cpu_count()) -> Iterable[bytes]:
+	random = Random(seed)
+
+	queue: SimpleQueue[Optional[ShuffleTask]] = SimpleQueue()
+
+	chunks: List[str] = []
+
+	try:
+		shufflers = [
+			Thread(target=shuffle_chunk, args=[queue])
+			for _ in range(threads if threads is not None else 1)
+		]
+
+		try:
+			for shuffler in shufflers:
+				shuffler.start()
+
+			for filename in split(fin, lines):
+				chunks.append(filename)
+				queue.put(ShuffleTask(random.random(), filename))
+		finally:
+			# Tell shufflers that they can stop waiting
+			for _ in shufflers:
+				queue.put(None)
+
+			# Wait for them to finish shuffling the last files
+			for shuffler in shufflers:
+				shuffler.join()
+
+		chunk_fds = [open(filename, 'rb', buffering=BUFSIZE) for filename in chunks]
+
+		while chunk_fds:
+			fd = random.choice(chunk_fds)
+			line = fd.readline()
+			if line == b'':
+				fd.close()
+				chunk_fds.remove(fd)
+				continue
+			yield line
+	finally:
+		for filename in chunks:
+			if os.path.exists(filename):
+				os.unlink(filename)
+
+
+class Reader(Iterable[bytes]):
+	"""Lazily opens a file only once you start trying to read it. Also magically
+	reads gzipped files."""
+	def __init__(self, filename:str):
+		self.filename = filename
+
+	def _read_gzip(self, filename:str) -> Iterable[bytes]:
+		child = subprocess.Popen(['gzip', '-cd', filename], stdout=subprocess.PIPE, bufsize=BUFSIZE)
+		assert child.stdout is not None
+		yield from child.stdout
+		if child.wait() != 0:
+			raise RuntimeError(f'`gzip -cd {filename}` failed with return code {child.returncode}')		
+
+	def _read_plain(self, filename:str) -> Iterable[bytes]:
+		with open(filename, 'rb') as fh:
+			yield from fh
+
+	def __iter__(self) -> Iterable[bytes]:
+		if self.filename.endswith('.gz'):
+			return self._read_gzip(self.filename)			
+		else:
+			return self._read_plain(self.filename)
+
+
+if __name__ == '__main__':
+	parser = ArgumentParser()
+	parser.add_argument('--chunksize', type=int, default=1_000_000)
+	parser.add_argument('--threads', '-j', type=int, default=os.cpu_count())
+	parser.add_argument('seed', type=int)
+	parser.add_argument('output', type=FileType('wb', bufsize=BUFSIZE), default='-')
+	parser.add_argument('files', nargs='+')
+
+	args = parser.parse_args()
+
+	args.output.writelines(shuffle(
+		chain.from_iterable(Reader(filename) for filename in args.files),
+		lines=args.chunksize,
+		seed=args.seed,
+		threads=args.threads))

--- a/trainer/shuffle.py
+++ b/trainer/shuffle.py
@@ -31,7 +31,7 @@ def chunked(iterable: Iterable[T], chunk_size:int) -> Iterable[Iterable[T]]:
 		pass
 
 
-def split(fh: Iterable[bytes], lines:int, dir=None) -> Iterable[str]:
+def split_into_tempfiles(fh: Iterable[bytes], lines:int, dir=None) -> Iterable[str]:
 	"""Split an iterable into a number of (temporary) files. Returns the
 	filenames. Note that you're responsible for deleting the tempfiles when
 	you're done with them."""
@@ -96,7 +96,7 @@ def shuffle(fin: Iterable[bytes], lines:int, *, seed: Optional[int] = None, thre
 				shuffler.start()
 
 			# Split the input file into separate temporary chunks
-			for filename in split(fin, lines):
+			for filename in split_into_tempfiles(fin, lines):
 				# Remember the chunk's filename for later
 				chunks.append(filename)
 				# And immediately start shuffling that chunk in another thread

--- a/trainer/shuffle.py
+++ b/trainer/shuffle.py
@@ -5,12 +5,11 @@ from shutil import which
 from argparse import ArgumentParser, FileType
 from itertools import islice, chain
 from tempfile import mkstemp
-from typing import TypeVar, Iterable, List, Optional, Union, Set
+from typing import TypeVar, Iterable, List, Optional
 from queue import Queue
 from threading import Thread
 from dataclasses import dataclass
 from random import Random
-from xxhash import xxh32
 
 
 # Buffer size for reading files. Bufsize that Python assigns is generally too small?
@@ -148,40 +147,11 @@ class Reader(Iterable[bytes]):
 			return self._read_plain(self.filename)
 
 
-LineType = TypeVar('LineType', bound=Union[str,bytes])
-
-def deduplicate(lines:Iterable[LineType], delimiter:LineType, columns:List[int]) -> Iterable[LineType]:
-	seen: Set[bytes] = set()
-	for line in lines:
-		fields = line.split(delimiter)
-		key = xxh32(delimiter.join(fields[col - 1] for col in columns)).digest()
-		if key in seen:
-			continue
-		seen.add(key)
-		yield line
-
-
-def intlist(desc:str) -> List[int]:
-	"""Turns '1-3,5' into [1,2,3,5]"""
-	ints = []
-	for rangedesc in desc.split(','):
-		if '-' in rangedesc:
-			first, last = rangedesc.split('-', 1)
-			ints.extend(range(int(first), int(last) + 1))
-		else:
-			ints.append(int(rangedesc))
-	return ints
-
-
 if __name__ == '__main__':
 	parser = ArgumentParser()
 	parser.add_argument('--batch-size', type=int, default=1_000_000, help='number of lines per chunk. Note that these chunks are read into memory when being shuffled')
 	parser.add_argument('--threads', '-j', type=int, default=2, help=f'number of concurrent shuffle threads. Defaults to 2')
 	parser.add_argument('--temporary-directory', '-T', type=str, help='temporary directory for shuffling batches')
-
-	parser.add_argument('--unique', '-u', type=intlist, default=[], action='append', help='deduplicate output based on these columns. Eg. `1` means no src-trg pair will have the same src side, but trg side can occur more than once. Can be specified multiple times to deduplicate separately. E.g. -u 1 -u 2 will make both source and target sides always be unique')
-	parser.add_argument('--delimiter', '-d', type=str, default='\t', help='delimiter for deduplication')
-
 	parser.add_argument('seed', type=int)
 	parser.add_argument('output', type=FileType('wb', bufsize=BUFSIZE), default='-')
 	parser.add_argument('files', nargs='+')
@@ -191,12 +161,6 @@ if __name__ == '__main__':
 	# Read the lines
 	it = chain.from_iterable(Reader(filename) for filename in args.files)
 
-	# Deduplicate lines before shuffling to make sure the deduplication is
-	# consistent regardless of the seed. Otherwise you might get different pairs
-	# when the shuffled order changed.
-	for column_list in args.unique:
-		it = deduplicate(it, delimiter=args.delimiter.encode(), columns=column_list)
-	
 	# Shuffle the lines
 	it = shuffle(it, lines=args.batch_size, seed=args.seed, threads=args.threads, tmpdir=args.temporary_directory)
 

--- a/trainer/test.py
+++ b/trainer/test.py
@@ -5,7 +5,7 @@ import unittest
 import tempfile
 import os
 
-from trainer import Dataset, DatasetReader, AsyncDatasetReader
+from trainer import Dataset, DatasetReader, AsyncDatasetReader, CurriculumLoader, Trainer, StateTracker
 
 TEST_FILE: str
 
@@ -27,12 +27,26 @@ class TestDatasetReader(unittest.TestCase):
 
 	reader: Type[DatasetReader] = DatasetReader
 
-	def test_read(self):
+	def test_repeating_read(self):
+		# Read 3000 lines
 		with closing(self.reader(Dataset('test', [TEST_FILE]), seed=1234)) as reader:
 			counter = Counter(line for _, line in zip(range(3000), reader))
 
+		# We should have 1000 unique lines (all lines in TEST_FILE)
 		self.assertEqual(len(counter), 1000)
+		# And each line should be read exactly 3 times
 		self.assertEqual(set(counter[key] for key in counter.keys()), {3})
+		# ideally in a different order than previous read.
+
+	def test_shuffled_read(self):
+		# Read 3000 lines
+		with closing(self.reader(Dataset('test', [TEST_FILE]), seed=1234)) as reader:
+			lines1 = [line for _, line in zip(range(1000), reader)]
+			lines2 = [line for _, line in zip(range(1000), reader)]
+		#	We should have read the same lines
+		self.assertEqual(frozenset(lines1), frozenset(lines2))
+		# but in a different order
+		self.assertNotEqual(lines1, lines2)
 
 	def test_offsets(self):
 		with closing(self.reader(Dataset('test', [TEST_FILE]), seed=1234)) as reader:
@@ -48,7 +62,7 @@ class TestDatasetReader(unittest.TestCase):
 			self.assertEqual(reader.epoch, 1)
 			self.assertEqual(reader.line, 750)
 
-	def test_resume(self):
+	def test_resume_offset(self):
 		counter = Counter()
 
 		with closing(self.reader(Dataset('test', [TEST_FILE]), seed=1234)) as reader1:
@@ -59,8 +73,80 @@ class TestDatasetReader(unittest.TestCase):
 			reader2.restore(state)
 			counter.update(line for _, line in zip(range(750), reader2))
 
+		# We should have read 250 + 750 lines exactly
 		self.assertEqual(len(counter), 1000)
+		# and they should be all read only once.
 		self.assertEqual(set(counter[key] for key in counter.keys()), {1})
+
+	def test_resume_order(self):
+		counter = Counter()
+
+		with closing(self.reader(Dataset('test', [TEST_FILE]), seed=1234)) as reader1, \
+			closing(self.reader(Dataset('test', [TEST_FILE]), seed=1234)) as reader2:
+			lines1 = [line for _, line in zip(range(250), reader1)]
+			reader2.restore(reader1.state())
+			lines1.extend(line for _, line in zip(range(750), reader2))
+
+		with closing(self.reader(Dataset('test', [TEST_FILE]), seed=1234)) as reader1, \
+			closing(self.reader(Dataset('test', [TEST_FILE]), seed=1234)) as reader2:
+			lines2 = [line for _, line in zip(range(500), reader1)]
+			reader2.restore(reader1.state())
+			lines2.extend(line for _, line in zip(range(500), reader2))
+
+		# Both reads should have the same amount and unique sentences
+		self.assertEqual(len(lines1), len(lines2))
+		self.assertEqual(set(lines1), set(lines2))
+		# They also should have the same order
+		self.assertEqual(lines1, lines2)
+
 
 class TestAsyncDatasetReader(TestDatasetReader):
 	reader = AsyncDatasetReader
+
+
+class TestTrainer(unittest.TestCase):
+	def test_resume(self):
+		config = {
+			'datasets': [
+				'test/data/clean',
+				'test/data/medium',
+				'test/data/dirty'
+			],
+			'stages': [
+				'start',
+				'mid'
+			],
+			'start': [
+				'clean 0.8',
+				'medium 0.2',
+				'dirty 0',
+				'until clean 1'
+			],
+			'mid': [
+				'clean 0.6',
+				'medium 0.3',
+				'dirty 0.1',
+				'until medium 1',
+			],
+			'seed': 1111
+		}
+		
+		curriculum = CurriculumLoader().load(config)
+
+		# Reference batches (trainer runs without resuming)
+		with closing(Trainer(curriculum)) as trainer_ref:
+			batches_ref = list(trainer_ref.run())
+
+		# State tracker (using tmpdir to make sure the file does not exist)
+		with tempfile.TemporaryDirectory() as tmpdir:
+			state_tracker = StateTracker(os.path.join(tmpdir, 'state_file'))
+
+			# Train on trainer1
+			with closing(Trainer(curriculum)) as trainer1:
+				batches = [batch for _, batch in zip(range(10), state_tracker.run(trainer1))]
+
+			# Resume on trainer2
+			with closing(Trainer(curriculum)) as trainer2:
+				batches.extend(state_tracker.run(trainer2))
+			
+		self.assertEqual(batches, batches_ref)

--- a/trainer/test.py
+++ b/trainer/test.py
@@ -1,6 +1,66 @@
-#!/usr/bin/env python3
-import sys
-with open('/tmp/test', 'w', encoding='utf-8') as outfile:
-    for line in sys.stdin:
-        outfile.write(line)
-        outfile.flush()
+from typing import IO, Type
+from collections import Counter
+from contextlib import closing
+import unittest
+import tempfile
+import os
+
+from trainer import Dataset, DatasetReader, AsyncDatasetReader
+
+TEST_FILE: str
+
+def setUpModule():
+	global TEST_FILE
+	fd, TEST_FILE = tempfile.mkstemp(text=True)
+	
+	with open(fd, 'w') as fh:
+		for n in range(1000):
+			fh.write(f'line{n}\n')
+
+
+def tearDownModule():
+	os.unlink(TEST_FILE)
+
+
+class TestDatasetReader(unittest.TestCase):
+	testset: IO[str]
+
+	reader: Type[DatasetReader] = DatasetReader
+
+	def test_read(self):
+		with closing(self.reader(Dataset('test', [TEST_FILE]), seed=1234)) as reader:
+			counter = Counter(line for _, line in zip(range(3000), reader))
+
+		self.assertEqual(len(counter), 1000)
+		self.assertEqual(set(counter[key] for key in counter.keys()), {3})
+
+	def test_offsets(self):
+		with closing(self.reader(Dataset('test', [TEST_FILE]), seed=1234)) as reader:
+			for _ in zip(range(500), reader):
+				pass
+
+			self.assertEqual(reader.epoch, 0)
+			self.assertEqual(reader.line, 500)
+
+			for _ in zip(range(1250), reader):
+				pass
+
+			self.assertEqual(reader.epoch, 1)
+			self.assertEqual(reader.line, 750)
+
+	def test_resume(self):
+		counter = Counter()
+
+		with closing(self.reader(Dataset('test', [TEST_FILE]), seed=1234)) as reader1:
+			counter.update(line for _, line in zip(range(250), reader1))
+			state = reader1.state()
+
+		with closing(self.reader(Dataset('test', [TEST_FILE]), seed=1234)) as reader2:
+			reader2.restore(state)
+			counter.update(line for _, line in zip(range(750), reader2))
+
+		self.assertEqual(len(counter), 1000)
+		self.assertEqual(set(counter[key] for key in counter.keys()), {1})
+
+class TestAsyncDatasetReader(TestDatasetReader):
+	reader = AsyncDatasetReader

--- a/trainer/test.py
+++ b/trainer/test.py
@@ -107,11 +107,11 @@ class TestAsyncDatasetReader(TestDatasetReader):
 class TestTrainer(unittest.TestCase):
 	def test_resume(self):
 		config = {
-			'datasets': [
-				'test/data/clean',
-				'test/data/medium',
-				'test/data/dirty'
-			],
+			'datasets': {
+				'clean': 'test/data/clean',
+				'medium': 'test/data/medium',
+				'dirty': 'test/data/dirty'
+			},
 			'stages': [
 				'start',
 				'mid'

--- a/trainer/test.py
+++ b/trainer/test.py
@@ -28,6 +28,9 @@ class TestDatasetReader(unittest.TestCase):
 	reader: Type[DatasetReader] = DatasetReader
 
 	def test_repeating_read(self):
+		"""Test whether when we read 3000 lines from a 1000 lines dataset we do
+		inded read each line 3 times.
+		"""
 		# Read 3000 lines
 		with closing(self.reader(Dataset('test', [TEST_FILE]), seed=1234)) as reader:
 			counter = Counter(line for _, line in zip(range(3000), reader))
@@ -39,6 +42,9 @@ class TestDatasetReader(unittest.TestCase):
 		# ideally in a different order than previous read.
 
 	def test_shuffled_read(self):
+		"""That that when we read 2000 lines from a 1000 line testfile, we read
+		each line twice, but we do read them in a different order.
+		"""
 		# Read 3000 lines
 		with closing(self.reader(Dataset('test', [TEST_FILE]), seed=1234)) as reader:
 			lines1 = [line for _, line in zip(range(1000), reader)]
@@ -49,6 +55,9 @@ class TestDatasetReader(unittest.TestCase):
 		self.assertNotEqual(lines1, lines2)
 
 	def test_offsets(self):
+		"""Test whether `epoch` and `line` properties of a DatasetReader are
+		counting properly.
+		"""
 		with closing(self.reader(Dataset('test', [TEST_FILE]), seed=1234)) as reader:
 			for _ in zip(range(500), reader):
 				pass
@@ -63,6 +72,10 @@ class TestDatasetReader(unittest.TestCase):
 			self.assertEqual(reader.line, 750)
 
 	def test_resume_offset(self):
+		"""Test whether resuming from a DatasetReader with the same testfile and the
+		same seed does indeed yield the entire dataset with no duplicates or
+		omissions.
+		"""
 		counter = Counter()
 
 		with closing(self.reader(Dataset('test', [TEST_FILE]), seed=1234)) as reader1:
@@ -79,6 +92,9 @@ class TestDatasetReader(unittest.TestCase):
 		self.assertEqual(set(counter[key] for key in counter.keys()), {1})
 
 	def test_resume_order(self):
+		"""Test whether when we resume reading a DatasetReader, the order is the
+		same as if we'd read everything from the initial (non-resumed) reader.
+		"""
 		counter = Counter()
 
 		with closing(self.reader(Dataset('test', [TEST_FILE]), seed=1234)) as reader1, \
@@ -101,11 +117,16 @@ class TestDatasetReader(unittest.TestCase):
 
 
 class TestAsyncDatasetReader(TestDatasetReader):
+	"""Run all the same tests, but on the async reader that shuffles in advance."""
 	reader = AsyncDatasetReader
 
 
 class TestTrainer(unittest.TestCase):
 	def test_resume(self):
+		"""End-to-end test for resuming training where we test that a resumed
+		trainer continues with the same sentences in the same order as the original
+		trainer would have, if it were to continue after dumping its state.
+		"""
 		config = {
 			'datasets': {
 				'clean': 'test/data/clean',

--- a/trainer/train_config.yml
+++ b/trainer/train_config.yml
@@ -1,8 +1,8 @@
 # Datasets are already TSV files
 datasets:
-  - test/data/clean
-  - test/data/medium
-  - test/data/dirty
+  clean: test/data/clean
+  medium: test/data/medium
+  dirty: test/data/dirty
 
 stages:
   - start
@@ -10,24 +10,26 @@ stages:
   - end
 
 start:
-  - clean 0.8
+  - clean  0.8
   - medium 0.2
-  - dirty 0
+  - dirty  0
   - until clean 2 # Until two epochs of clean
 
 mid:
-  - clean 0.6
+  - clean  0.6
   - medium 0.3
-  - dirty 0.1
+  - dirty  0.1
   - until medium 1
 
 end:
-  - clean 0.4
+  - clean  0.4
   - medium 0.3
-  - dirty 0.3
+  - dirty  0.3
   - until dirty 5 # use `inf` to mean until forever
 
-uppercase: 0.05
-titlecase: 0.05
+modifiers:
+  - uppercase 0.05
+  - titlecase 0.05
+
 seed: 1111
 trainer: /home/dheart/uni_stuff/postdoc/empty-train/trainer/test.py

--- a/trainer/train_config_bgen.yml
+++ b/trainer/train_config_bgen.yml
@@ -1,10 +1,10 @@
 # Datasets are already TSV files
 datasets:
-  - test/data/bt.bgen.pls
-  - test/data/clean.bgen.pls
-  - test/data/medium.bgen.pls
-  - test/data/dirty.bgen.pls
-  - test/data/web.bgen.pls
+  bt: test/data/bt.bgen.pls
+  clean: test/data/clean.bgen.pls
+  medium: test/data/medium.bgen.pls
+  dirty: test/data/dirty.bgen.pls
+  web: test/data/web.bgen.pls
 
 stages:
   - bt
@@ -13,39 +13,41 @@ stages:
   - end
 
 bt:
-  - bt.bgen.pls 0.8
-  - clean.bgen.pls 0.2
-  - medium.bgen.pls 0
-  - dirty.bgen.pls 0
-  - web.bgen.pls 0
-  - until bt.bgen.pls 2
+  - bt     0.8
+  - clean  0.2
+  - medium 0
+  - dirty  0
+  - web    0
+  - until bt 2
 
 start:
-  - bt.bgen.pls 0.1
-  - clean.bgen.pls 0.7
-  - medium.bgen.pls 2
-  - dirty.bgen.pls 0
-  - web.bgen.pls 0
-  - until clean.bgen.pls 3
+  - bt     0.1
+  - clean  0.7
+  - medium 2
+  - dirty  0
+  - web    0
+  - until clean 3
 
 mid:
-  - bt.bgen.pls 0
-  - clean.bgen.pls 0.6
-  - medium.bgen.pls 0.3
-  - dirty.bgen.pls 0.1
-  - web.bgen.pls 0
-  - until medium.bgen.pls 1
+  - bt     0
+  - clean  0.6
+  - medium 0.3
+  - dirty  0.1
+  - web    0
+  - until medium 1
 
 end:
-  - bt.bgen.pls 0
-  - clean.bgen.pls 0.4
-  - medium.bgen.pls 0.3
-  - dirty.bgen.pls 0.2
-  - web.bgen.pls 0.1
-  - until dirty.bgen.pls 2
+  - bt     0
+  - clean  0.4
+  - medium 0.3
+  - dirty  0.2
+  - web    0.1
+  - until dirty 2
 
-uppercase: 0.05
-titlecase: 0.05
+modifiers:
+  - uppercase 0.05
+  - titlecase 0.05
+
 seed: 1111
 trainer: /home/dheart/uni_stuff/postdoc/empty-train/trainer/test.py
 

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -502,7 +502,7 @@ class Trainer:
                 # TODO: maybe make this self.stage.modifiers? Would that make sense?
                 for modifier in self.curriculum.modifiers:
                     modifier_fun = MODIFIERS[modifier.name]
-                    batch = [modifier_fun(line) if modifier.frequency > random.random() else line for line in batch]
+                    batch = [modifier_fun(line.rstrip('\n')) + '\n' if modifier.frequency > random.random() else line for line in batch]
 
                 random.shuffle(batch)
 

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -567,17 +567,17 @@ if __name__ == '__main__':
     if args.do_not_resume:
         state_harness._restore = lambda trainer: None
 
-    model = subprocess.Popen(
+    model_trainer = subprocess.Popen(
         config['trainer'],
         stdin=subprocess.PIPE,
         encoding="utf-8",
         preexec_fn=ignore_sigint) # ignore_sigint makes marian ignore Ctrl-C. We'll stop it from here.
     
-    assert model.stdin is not None
+    assert model_trainer.stdin is not None
 
     try:
         for batch in state_harness.run(trainer):
-            model.stdin.writelines(batch)
+            model_trainer.stdin.writelines(batch)
     finally:
-        model.stdin.close()
-        model.wait()
+        model_trainer.stdin.close()
+        model_trainer.wait()

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -24,8 +24,8 @@ def ignore_sigint():
     signal.signal(signal.SIGINT, signal.SIG_IGN)
 
 # Path to something that can shuffle data. Called with seed, output-path, input-files
-# Ideally this also deduplicates the src side of the sentence pairs it shuffles ;)
-PATH_TO_SHUFFLE = os.path.dirname(os.path.realpath(__file__)) + "/random.sh"
+# TODO: Ideally this also deduplicates the src side of the sentence pairs it shuffles ;)
+PATH_TO_SHUFFLE = os.path.dirname(os.path.realpath(__file__)) + "/shuffle.py"
 
 # Available batch modifiers
 MODIFIERS = {

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -445,7 +445,6 @@ class StateTracker:
 
         try:
             for batch in trainer.run(*args, **kwargs):
-                self._dump(trainer)
                 yield batch
         finally:
             # Dump on clean exit as well as exception.

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -643,7 +643,6 @@ if __name__ == '__main__':
 
     model_trainer = subprocess.Popen(
         args.trainer or config['trainer'],
-        bufsize=0, # no limbo for lines written but not yet read by marian
         stdin=subprocess.PIPE,
         encoding="utf-8",
         preexec_fn=ignore_sigint) # ignore_sigint makes marian ignore Ctrl-C. We'll stop it from here.

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -155,7 +155,7 @@ class DatasetReader:
             self._fh.close()
 
     def _open(self):
-        print("[Trainer] Reading {self.dataset.name} for epoch {self.epoch}")
+        print(f"[Trainer] Reading {self.dataset.name} for epoch {self.epoch}")
         # Open temporary file which will contain shuffled version of `cat self.files`
         fh = TemporaryFile(mode='w+', encoding='utf-8', dir=self.tmpdir)
 
@@ -263,7 +263,7 @@ class AsyncDatasetReader(DatasetReader):
         self._pending = None
 
     def _open(self):
-        print("[Trainer] Reading {self.dataset.name} for epoch {self.epoch}")
+        print(f"[Trainer] Reading {self.dataset.name} for epoch {self.epoch}")
 
         # First time self._pending is None, but all subsequent calls to _open
         # should have self._pending be set.
@@ -563,7 +563,7 @@ class Trainer:
 
     def run(self, *, batch_size=100):
         while self.stage is not None:
-            print("[Trainer] Starting stage {self.stage.name}")
+            print(f"[Trainer] Starting stage {self.stage.name}")
             while self.stage.until_epoch is not None and self.epoch_tracker.epoch < self.stage.until_epoch:
                 batch: List[str] = []
 

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -13,7 +13,6 @@ from dataclasses import dataclass
 from typing import List, Tuple, Dict, Any, Optional, Union, Type, TextIO, cast
 from tempfile import TemporaryFile
 from itertools import islice
-from warnings import warning
 
 import yaml
 

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 from typing import List, Tuple, Dict, Any, Optional, Union, Type, TextIO, cast
 from tempfile import TemporaryFile
 from itertools import islice
+from warnings import warning
 
 import yaml
 
@@ -638,7 +639,7 @@ if __name__ == '__main__':
 
     # Quick cheap check that all files exist before we begin training
     for dataset in curriculum.datasets.values():
-        missing_files = {file for file in dataset.files if not os.path.exist(file)}
+        missing_files = {file for file in dataset.files if not os.path.exists(file)}
         if missing_files:
             raise ValueError(f"Dataset '{dataset.name}' is missing files: {missing_files}")
 

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -659,6 +659,11 @@ if __name__ == '__main__':
             model_trainer.stdin.close()
             model_trainer.wait()
         except KeyboardInterrupt:
-            print("[Trainer] Ctrl-c pressed again, terminating trainer")
-            model_trainer.terminate()
-            model_trainer.wait()
+            try:
+                print("[Trainer] Ctrl-c pressed again, terminating trainer")
+                model_trainer.terminate()
+                model_trainer.wait()
+            except KeyboardInterrupt:
+                print("[Trainer] Ctrl-c pressed third time, killing trainer")
+                model_trainer.kill()
+                model_trainer.wait()

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -2,22 +2,18 @@
 '''A translation model trainer. It feeds marian different sets of datasets with different thresholds
 for different stages of the training. Data is uncompressed and TSV formatted src\ttrg'''
 import os
-import io
+import sys
 import signal
 import argparse
-import weakref
 import random
 import subprocess
 
-from sys import stderr
 from dataclasses import dataclass
-from subprocess import check_call, CalledProcessError
-from collections import namedtuple
-from typing import List, Tuple, Dict, Union, Any
-from math import inf
+from typing import List, Tuple, Dict, Any, Optional, Union, TextIO, cast
+from tempfile import TemporaryFile
+from itertools import islice
 
 import yaml
-from yaml.loader import SafeLoader, Loader
 
 def ignore_sigint():
     signal.signal(signal.SIGINT, signal.SIG_IGN)
@@ -26,321 +22,373 @@ def parse_user_args():
     """Parse the arguments necessary for this filter"""
     parser = argparse.ArgumentParser(description="Feeds marian tsv data for training.")
     parser.add_argument("--config", '-c', required=True, type=str, help='YML configuration input.')
-    parser.add_argument("--temporary-dir", '-t', default="./TMP", type=str, help='Temporary dir, used for shuffling and tracking state')
+    parser.add_argument("--state", '-s', type=str, help='YML state file, defaults to ${CONFIG}.state.')
+    # parser.add_argument("--temporary-dir", '-t', default="./TMP", type=str, help='Temporary dir, used for shuffling and tracking state')
     parser.add_argument("--do-not-resume", '-d', action="store_true", help='Do not resume from the previous training state')
     return parser.parse_args()
 
-Stage = namedtuple('Stage', ['name', 'datasets', 'until_dataset', 'until_epoch'])
+# Path to something that can shuffle data. Called with seed, output-path, input-files
+# Ideally this also deduplicates the src side of the sentence pairs it shuffles ;)
+PATH_TO_SHUFFLE = os.path.dirname(os.path.realpath(__file__)) + "/random.sh"
 
-DatasetState = namedtuple('DatasetState', ['name', 'seed', 'line', 'epoch'])
-
-@dataclass
-class StateTracker:
-    '''The purpose of this class is to store an yml of every single state during training'''
-    def __init__(self, ymlpath, restore=True):
-        '''Tries to load the state from previous yml, else just writes a new yml. If restore==False
-           it always overwrites the previous input'''
-        self.ymlpath = ymlpath
-        self.stage: Union[str, None] = None
-        self.dataset_states: Dict['str', DatasetState] = {}
-        self.random_state = None
-        if restore and os.path.isfile(self.ymlpath) and os.access(self.ymlpath, os.R_OK):
-            with open(self.ymlpath, 'rt', encoding="utf-8") as myfile:
-                ymldata = list(yaml.load_all(myfile, Loader=Loader))[0]
-                self.stage = ymldata['stage']
-                datasets: dict = ymldata['datasets']
-                for dataset, [seed, line, epoch] in datasets.items():
-                    name = dataset
-                    seed = int(seed)
-                    line = int(line)
-                    epoch = int(epoch)
-                    self.dataset_states[name] = DatasetState(name, seed, line, epoch)
-                # Restore random state
-                self.random_state = ymldata['random_state']
-                random.setstate(self.random_state)
-
-    def dump(self) -> None:
-        '''Dumps the current state to yml.
-        This should only be called when there is a model save detected'''
-        with open(self.ymlpath, 'w', encoding="utf-8") as ymlout:
-            output = {}
-            output['stage'] = self.stage
-            output['datasets'] = {}
-            for dataset, state in self.dataset_states.items():
-                seed = state.seed
-                line = state.line
-                epoch = state.epoch
-                output['datasets'][dataset] = [seed, line, epoch]
-                output['random_state'] = self.random_state
-            yaml.dump(output, ymlout, allow_unicode=True)
-
-    def update_stage(self, newstage: str) -> None:
-        '''Update the training stage'''
-        self.stage = newstage
-
-    def update_seed(self) -> None:
-        '''Updates the random seed'''
-        self.random_state = random.getstate()
-
-    def update_dataset(self, dataset_name: str, dataset_state: DatasetState) -> None:
-        '''Updates the state of the current dataset'''
-        self.dataset_states[dataset_name] = dataset_state
-
-    def restore_random_state(self) -> None:
-        '''Restores the random state'''
-        if self.random_state is not None:
-            random.setstate(self.random_state)
-        else:
-            print("Error! Random state restoration")
-
-    def get_dataset(self, name: str) -> DatasetState:
-        '''Returns the state for a dataset'''
-        return self.dataset_states[name]
+# Available batch modifiers
+MODIFIERS = {
+    'uppercase': lambda line: line.upper(),
+    'titlecase': lambda line: ' '.join([word[0].upper() + word[1:] for word in line.split()]),
+}
 
 
-@dataclass
-class Executor:
-    '''This class takes in the config file and starts running training'''
-    def __init__(self, ymlpath: str, tmpdir: str, state_tracker: StateTracker):
-        # Perform configuration file parsing
-        with open(ymlpath, 'rt', encoding="utf-8") as myfile:
-            ymldata: Dict[str, Any] = list(yaml.load_all(myfile, Loader=SafeLoader))[0]
-
-        # Get individual path names and correlate dataset path with dataset name:
-        self.dataset_paths: Dict[str, str] = {}
-        for path in ymldata['datasets']:
-            self.dataset_paths[path.split('/')[-1]] = path
-        self.stage_names: List[str] = ymldata['stages']
-        self.uppercase_ratio = float(ymldata['uppercase'])
-        self.titlecase_ratio = float(ymldata['titlecase'])
-        self.random_seed = int(ymldata['seed'])
-        random.seed(self.random_seed)
-
-        # Initialise the trainer, using Subprocess.Popen
-        self.trainer = subprocess.Popen(ymldata['trainer'], stdout=None, stderr=None, stdin=subprocess.PIPE, encoding="utf-8", preexec_fn=ignore_sigint)
-
-        # Parse the individual training stages into convenient struct:
-        self.stages: Dict[str, Stage] = {}
-        self.dataset_objects: Dict[str, Dataset] = {}
-
-        for stage in self.stage_names:
-            stageparse: List[str] = ymldata[stage]
-            # We only want the first N - 1 as the last one describes the finishing condition
-            stagesdict = {}
-            for i in range(len(stageparse) -1):
-                stagename, weight = stageparse[i].split()
-                weight = float(weight)
-                stagesdict[stagename] = weight
-
-            _, until_stagename, termination_epoch = stageparse[-1].split()
-            mystage = Stage(stage, stagesdict, until_stagename, float(termination_epoch))
-            self.stages[stage] = mystage
-
-        # Initialise the dataset filestreams. For now just do identity initialisation, do more later
-        for dataset, path in self.dataset_paths.items():
-            self.dataset_objects[dataset] = Dataset(path, tmpdir, self.random_seed, 0.1, inf, state_tracker)
-
-        # Keep track of the state. The restore_datasets variable will keep track of whether to restore the datasets to
-        # a certain stage at the initial run before continueing forward.
-        self.state_tracker = state_tracker
-        self.restore_datasets: bool = state_tracker.stage is not None
-        self._restore_()
-
-        # Main training loop.
-        try:
-            for stage in self.stage_names:
-                print(stage)
-                self._init_stage_(self.stages[stage])
-                # The first time we get here, if we are resuming training, we need to restore the dataset state
-                # Restore state and then don't do it again:
-                if self.restore_datasets:
-                    for dataset in self.stages[stage].datasets.keys():
-                        mystate: DatasetState = self.state_tracker.get_dataset(dataset)
-                        self.dataset_objects[dataset].restore_state(mystate)
-                        print("Restoring dataset:", dataset, "to seed:", mystate.seed, "line:", mystate.line, "epoch:", mystate.epoch)
-                    self.restore_datasets = False
-                self.state_tracker.update_stage(stage)
-                self.train_stage(self.stages[stage])
-        finally:
-            # Finalise the trainer by cleanly closing any open subprocesses
-            self.finaliser()
-
-    def _init_stage_(self, stage: Stage): #@TODO make the stupid stage a full object so i can have proper attributes
-        '''Init a certain stage of the training'''
-        for dataset in stage.datasets.keys():
-            self.dataset_objects[dataset].set_weight(stage.datasets[dataset])
-            self.dataset_objects[dataset].set_max_epoch(inf)
-            self.dataset_objects[dataset].reset_epoch()
-        self.dataset_objects[stage.until_dataset].set_max_epoch(stage.until_epoch)
-
-    def _restore_(self) -> None:
-        """Restores the training state from a state tracker"""
-        # Skip training stages based on if we are resuming the training
-        if self.state_tracker.stage is not None:
-            resume_stage_idx = self.stage_names.index(self.state_tracker.stage)
-            print("Skipping training stages", self.stage_names[0:resume_stage_idx], "as we are resuming training")
-            self.stage_names = self.stage_names[resume_stage_idx:]
-            # Restore random state
-            self.state_tracker.restore_random_state()
-
-    def train_stage(self, stage):
-        '''Trains up to a training stage'''
-        # Make sure that we check the stopping criteria before starting to train so we don't continue
-        # training after we have finished everything else first.
-        stop_training: bool = self.dataset_objects[stage.until_dataset].epoch >= stage.until_epoch
-        while not stop_training:
-            batch = []
-            for dataset in stage.datasets:
-                _, lines = self.dataset_objects[dataset].get()
-                #print(epoch, dataset, stage.until_dataset, stage.until_epoch, len(lines))
-                batch.extend(lines)
-            # Shuffle the batch
-            random.shuffle(batch)
-            # apply modifications:
-            batch = self.modify_batch(batch)
-            self.trainer.stdin.writelines(batch)
-            self.state_tracker.update_seed()
-            # Termination condition, check if we finished training.
-            stop_training = self.dataset_objects[stage.until_dataset].epoch >= stage.until_epoch
-
-    def modify_batch(self, batch: List[str]) -> List[str]:
-        '''Modifies the batch to add uppercasing, tittle casing, placeholding'''
-        # Uppercase randomly
-        if self.uppercase_ratio > 0:
-            batch = [x.upper() if random.random() < self.uppercase_ratio else x for x in batch]
-        # titlecase randomly. We also add a new line to every string because calling split() removes it
-        if self.titlecase_ratio > 0:
-            batch = [" ".join([i[0].upper() + i[1:] for i in x.split()]) + "\n" if random.random() < self.titlecase_ratio else x for x in batch]
-
-        # Apply placeholders randomly
-        return batch
-
-    def finaliser(self) -> None:
-        '''Terminates the child process and waits for it to exit cleanly.'''
-        self.trainer.stdin.close()
-        self.trainer.wait()
-
-
-
-@dataclass
+@dataclass(frozen=True)
 class Dataset:
-    '''This class takes care of iterating through a dataset. It takes care of shuffling and
-    remembering the position of the dataset'''
-    def __init__(self, datapath: str, tmpdir: str, seed: int, weight: float, max_epoch: int, state_tracker: StateTracker):
-        # Create the temporary directory if it doesn't exist
-        if not os.path.exists(tmpdir):
-            os.makedirs(tmpdir)
-        self.state_tracker = state_tracker
-        # Vars
-        self.orig = datapath
-        self.filename: str = datapath.split('/')[-1]
-        self.tmpdir = tmpdir
+    name: str
+    files: List[str]
+
+    
+@dataclass(frozen=True)
+class DatasetState:
+    seed: int
+    line: int
+    epoch: int
+
+
+@dataclass(frozen=True)
+class Stage:
+    name: str
+    datasets: List[Tuple[Dataset, float]]
+    until_dataset: str
+    until_epoch: Optional[int]
+
+
+@dataclass(frozen=True)
+class Modifier:
+    name: str
+    frequency: float
+
+
+@dataclass(frozen=True)
+class Curriculum:
+    seed: int
+    datasets: Dict[str,Dataset]
+    stages: Dict[str,Stage]
+    modifiers: List[Modifier]
+    stages_order: List[str]
+
+    def next_stage(self, stage:Stage) -> Optional[Stage]:
+        index = self.stages_order.index(stage.name)
+        if index + 1 < len(self.stages_order):
+            return self.stages[self.stages_order[index + 1]]
+        else:
+            return None
+
+
+@dataclass(frozen=True)
+class TrainerState:
+    stage: str
+    random_state: Any
+    datasets: Dict[str,DatasetState]
+
+
+class DatasetReader:
+    dataset: Dataset
+    seed: int
+    line: int
+    epoch: int
+
+    _fh: Optional[TextIO] = None
+
+    def __init__(self, dataset:Dataset, seed:int):
+        self.dataset = dataset
         self.seed = seed
-        self.linenum = 0 # line number of the current file
-        self.shufffile = self.tmpdir + "/" + self.filename + ".shuf"
-        self.weight = weight
-        # filehandle
-        self.filehandle: io.TextIOBase = None
-        # dataset epoch
-        self.epoch = 0
-        self.max_epoch = max_epoch
-
-        self.rng_filepath = str(os.path.dirname(os.path.realpath(__file__))) + "/random.sh" # HACKY
-
-        # shuffle the initial file
-        self._shuffle_(self.orig, self.shufffile)
-        # Open the current file for reading
-        self._openfile_(self.shufffile)
-
-        # On object destruction, cleanup
-        self._finalizer = weakref.finalize(self, self._cleanup_, self.filehandle)
-
-    def set_weight(self, neweight):
-        '''Used for when we want to switch the sampling strategy based on our schedule'''
-        self.weight = neweight
-
-    def set_max_epoch(self, new_max_epoch):
-        '''Used for when we want to switch the sampling strategy based on our schedule'''
-        self.max_epoch = new_max_epoch
-
-    def reset_epoch(self):
-        '''Used to reset the training epoch of the file, so that training can continue
-        from the same shuffling point without eextra fluff'''
         self.epoch = 0
 
-    def _ammend_seed_(self, newseed=None):
-        '''Either adds one to the current random seed, or sets a new one completely'''
-        if newseed is None:
-            newseed = self.seed + 1
-        self.seed = newseed
+    def state(self) -> DatasetState:
+        return DatasetState(self.seed, self.line, self.epoch)
 
-    def _shuffle_(self, inputfile, outputfile):
-        try:
-            #print(self.rng, outputfile, inputfile)
-            check_call([self.rng_filepath, str(self.seed), outputfile, inputfile])
-            #check_call(["/usr/bin/shuf", "-o", outputfile, inputfile])
-        except CalledProcessError as err:
-            print("Error shuffling", inputfile, file=stderr)
-            print(err.cmd, file=stderr)
-            print(err.stderr, file=stderr)
+    def restore(self, state:DatasetState) -> 'DatasetReader':
+        if self._fh:
+            self._fh.close()
 
-    def _openfile_(self, filepath):
-        self.filehandle = open(filepath, 'rt', encoding="utf-8")
-
-    def get(self) -> Tuple[int, List[str]]:
-        '''Gets the next N lines based on the weight of the dataset. It also reports which
-        epoch it is.
-        When the dataset reaches its end, it automatically takes care of wrapping it'''
-        myepoch = self.epoch
-        retlist: List[str] = []
-        try:
-            for _ in range(int(self.weight*100)):
-                retlist.append(next(self.filehandle))
-                self.linenum = self.linenum + 1
-        except StopIteration:
-            # Update seed and re-shuffle the file UNLESS we have reached the max epoch
-            if self.epoch < self.max_epoch:
-                self.filehandle.close()
-                self._ammend_seed_()
-                self._shuffle_(self.orig, self.shufffile)
-                self._openfile_(self.shufffile)
-                self.epoch = self.epoch + 1
-                self.linenum = 0
-        # Send statistics to the state tracker
-        name = self.filename
-        state = DatasetState(name, self.seed, self.linenum, self.epoch)
-        self.state_tracker.update_dataset(name, state)
-        return (myepoch, retlist)
-
-    def restore_state(self, state: DatasetState) -> None:
-        '''Restores the state from a previous training run'''
-        self.filehandle.close()
         self.seed = state.seed
         self.epoch = state.epoch
-        self._shuffle_(self.orig, self.shufffile)
-        self._openfile_(self.shufffile)
-        i = 0
-        while i < state.line:
-            self.filehandle.readline()
-            i = i + 1
-            self.linenum = self.linenum + 1
+        
+        # Skip forward
+        for _ in range(state.line):
+            next(self)
+
+        return self
+
+    def close(self):
+        if self._fh:
+            self._fh.close()
+
+    def _open(self):
+        # Open temporary file which will contain shuffled version of `cat self.files`
+        fh = TemporaryFile(mode='w+', encoding='utf-8')
+
+        # Shuffle data to the temporary file
+        subprocess.check_call([PATH_TO_SHUFFLE, str(self.seed), str(fh.fileno()), *self.dataset.files], pass_fds=(fh,))
+
+        # Replace open file handle with this new file
+        self._fh = cast(TextIO, fh) # TODO: Not sure why TemporaryFile is an IO[str]
+        self.line = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        just_opened = False
+        if not self._fh:
+            just_opened = True
+            self._open() # TODO: do we want to do this lazy? Yes, restore()
+                         # might be called twice right now and shuffling is
+                         # expensive.
+
+        assert self._fh is not None
+        try:
+            # Try to read the next line from our shuffled file
+            line = next(self._fh)
+            self.line += 1
+            return line
+        except StopIteration:
+            if just_opened:
+                raise RuntimeError('reading from empty shuffled file')
+
+            # Oh no we're out of lines! Close file, and move on to the next epoch
+            self._fh.close()
+            self.seed += 1
+            self.epoch += 1
+
+            # Now try again (will trigger the lazy open + just_opened protection)
+            return next(self)
+                
 
 
-    @staticmethod
-    def _cleanup_(my_filehandle):
-        if my_filehandle:
-            my_filehandle.close()
-        # No need to save state, we should have the latest kept in the state tracker
+class StateLoader:
+    def load(self, fh:TextIO) -> TrainerState:
+        ymldata = yaml.safe_load(fh)
+        return TrainerState(
+            stage=ymldata['stage'],
+            random_state=ymldata['random_state'],
+            datasets={
+                dataset_name: DatasetState(int(seed), int(line), int(epoch))
+                for dataset_name, [seed, line, epoch] in ymldata['datasets'].items()
+            }
+        )
 
-    def _exit_(self, exc_type, exc_value, traceback):
-        self._finalizer()
+    def dump(self, state:TrainerState, fh:TextIO) -> None:
+        yaml.safe_dump({
+            'stage': state.stage,
+            'random_state': state.random_state,
+            'datasets': {
+                dataset_name: [state.seed, state.line, state.epoch] #TODO: why a tuple, why not a dict? Isn't a dict more forward compatible?
+                for dataset_name, state in state.datasets.items()
+            }
+        }, fh, allow_unicode=True, sort_keys=False) #TODO: is safe_dump not sufficient?
+
+
+class CurriculumLoader:
+    def load(self, fh:Union[TextIO,str,dict]) -> Curriculum:
+        if isinstance(fh, dict):
+            ymldata = fh
+        else:
+            ymldata = yaml.safe_load(fh)
+
+        seed = int(ymldata['random_seed'])
+
+        datasets = {
+            name: Dataset(name, files)
+            for name, files in ymldata['datasets']
+        }
+
+        stages_order = list(ymldata['stages'])
+
+        return Curriculum(
+            seed=seed,
+            datasets=datasets,
+            stages_order=stages_order,
+            stages={
+                stage_name: self._load_stage(ymldata, stage_name, datasets, seed)
+                for stage_name in stages_order
+            },
+            modifiers=[
+                self._load_modifier(modifier_line)
+                for modifier_line in ymldata.get('modifiers', [])
+            ]
+        )
+
+    def _load_stage(self, ymldata:dict, stage_name:str, available_datasets:Dict[str,Dataset], seed:int) -> Stage:
+        datasets: List[Tuple[Dataset, float]] = []
+
+        for line in ymldata[stage_name][:-1]:
+            dataset_name, weight = line.split()
+            datasets.append((available_datasets[dataset_name], float(weight)))
+
+        _, dataset_name, max_epochs = ymldata[stage_name][-1].split()
+        assert dataset_name in available_datasets, f"until clause of stage '{stage_name}' refers to unknown dataset '{dataset_name}'"
+        assert dataset_name in {dataset.name for dataset, weight in datasets if weight > 0.0}, f"until clause of stage '{stage_name}' watches dataset '{dataset_name}' but that dataset is not read during this stage"
+        return Stage(
+            name=stage_name,
+            datasets=datasets,
+            until_dataset=dataset_name,
+            until_epoch=int(max_epochs) if max_epochs is not 'inf' else None
+        )
+
+    def _load_modifier(self, line:str) -> Modifier:
+        name, frequency = line.split()
+        assert name in MODIFIERS, f"unknown modifier named '{name}'"
+        return Modifier(name, float(frequency))
+
+
+class Trainer:
+    curriculum: Curriculum
+    stage: Optional[Stage]
+    readers: Dict[str, DatasetReader]
+    trainer: subprocess.Popen
+
+    _slice_size = 100
+
+    '''This class takes in the config file and starts running training'''
+    def __init__(self, curriculum:Curriculum):
+        self.curriculum = curriculum
+        random.seed(self.curriculum.seed)
+        first_stage_name = self.curriculum.stages_order[0]
+        first_stage = self.curriculum.stages[first_stage_name]
+
+        #TODO: make sure this doesn't do too much work in case we call
+        # restore() manually anyway.
+        self.restore(TrainerState(
+            stage=first_stage_name,
+            random_state=random.getstate(),
+            datasets={
+                dataset.name: DatasetState(seed=curriculum.seed, line=0, epoch=0)
+                for dataset, _ in first_stage.datasets
+            }
+        ))
+
+    def restore(self, state:TrainerState):
+        random.setstate(state.random_state)
+        self.stage = self.curriculum.stages[state.stage]
+        self.readers = {
+            dataset_name: reader.restore(state.datasets[dataset_name])
+            for dataset_name, reader in self._create_readers(self.stage).items()
+        }
+
+    def _create_readers(self, stage:Stage) -> Dict[str,DatasetReader]:
+        return {
+            dataset.name: DatasetReader(dataset, self.curriculum.seed)
+            for dataset, _ in stage.datasets
+        }
+
+    def state(self) -> TrainerState:
+        return TrainerState(
+            stage=self.stage.name if self.stage is not None else '',
+            random_state=random.getstate(),
+            datasets={
+                name: reader.state()
+                for name, reader in self.readers.items()
+            }
+        )
+
+    def run(self, config:Dict[str,Any]):
+        # Initialise the trainer, using Subprocess.Popen
+        self.trainer = subprocess.Popen(
+            config['trainer'],
+            stdin=subprocess.PIPE,
+            encoding="utf-8",
+            preexec_fn=ignore_sigint) # ignore_sigint makes marian ignore Ctrl-C. We'll stop it from here.
+
+        # Stop type checker from complaining that stdin may be None anyway
+        assert self.trainer.stdin is not None
+
+        try:
+            while self.stage is not None:
+                # Quick access to the reader that determines whether we have
+                # read it enough times for this stage to finish and move onto
+                # the next.
+                until_reader = self.readers[self.stage.until_dataset]
+
+                while self.stage.until_epoch is not None and until_reader.epoch < self.stage.until_epoch:
+                    batch: List[str] = []
+
+                    # Read from each dataset according to its weight in this stage
+                    # (They will reshuffle and repeat if necessary)
+                    for dataset, weight in self.stage.datasets:
+                        batch.extend(islice(self.readers[dataset.name], 0, int(self._slice_size * weight)))
+
+                    # Apply any modifiers to random lines in the batch
+                    # (Multiple modifiers could be applied to the same line!)
+                    # TODO: maybe make this self.stage.modifiers? Would that make sense?
+                    for modifier in self.curriculum.modifiers:
+                        modifier_fun = MODIFIERS[modifier.name]
+                        batch = [modifier_fun(line) for line in batch if modifier.frequency > random.random()]
+
+                    random.shuffle(batch)
+
+                    # Pass batch to trainer. Might block on writing it. Uses default
+                    # buffer size, and most likely the trainer will read it async
+                    # from training anyway.
+                    self.trainer.stdin.writelines(batch)
+
+                    # Tell anyone whose listening that something interesting happend
+                    # TODO: Yield something useful, e.g. progress.
+                    yield None
+
+                # Move onto next stage. May be `None`, which would end this generator 🎉
+                self.stage = self.curriculum.next_stage(self.stage)
+                self.readers = self._create_readers(self.stage) if self.stage is not None else {}
+        finally:
+            # Whatever you do, clean up the trainer.
+            self.trainer.stdin.close()
+            self.trainer.wait()
+
+
+class StateTracker:
+    path: str
+    loader: StateLoader
+
+    def __init__(self, path:str, *, loader:StateLoader=StateLoader()):
+        self.path = path
+        self.loader = loader
+
+    def _restore(self, trainer:Trainer):
+        with open(self.path, 'r', encoding='utf-8') as fh:
+            return trainer.restore(self.loader.load(fh))
+
+    def _dump(self, trainer:Trainer):
+        with open(self.path, 'w', encoding='utf-8') as fh:
+            return self.loader.dump(trainer.state(), fh)
+
+    def run(self, trainer:Trainer, *args, **kwargs):
+        if os.path.exists(self.path):
+            self._restore(trainer)
+
+        try:
+            for batch in trainer.run(*args, **kwargs):
+                self._dump(trainer)
+                yield batch
+        finally:
+            # Dump on clean exit as well as exception.
+            self._dump(trainer)
 
 
 if __name__ == '__main__':
     args = parse_user_args()
-    config = args.config
-    mytmpdir = args.temporary_dir
-    mystate_tracker = StateTracker(mytmpdir + '/state.yml', not args.do_not_resume)
 
-    executor = Executor(config, mytmpdir, mystate_tracker)
-    mystate_tracker.dump() # //@TODO execute this in a cleanup (eg child process dies/we receive a kill signal)
+    with open(args.config, 'r', encoding='utf-8') as fh:
+        config = yaml.safe_load(fh)
+
+    curriculum = CurriculumLoader().load(config)
+
+    trainer = Trainer(curriculum)
+
+    state_harness = StateTracker(args.state or f'{args.config}.state')
+
+    # Disable resume functionality if we don't want it.
+    if args.do_not_resume:
+        state_harness._restore = lambda trainer: None
+
+    # Run trainer as a generator. Ideally we get some stats back about
+    # the batch we just pushed to it, but since marian is probably reading and
+    # training in separate threads, I'm doubtful about how useful this is.
+    for _ in state_harness.run(trainer, config):
+        pass

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -330,15 +330,14 @@ class CurriculumV1Loader:
 
     def _load_datasets(self, ymldata:dict, basepath:str) -> Dict[str,Dataset]:
         """Reads
-        ```yaml
+        ```yml
         datasets:
-          - path/to/clean
-          - path/to/dirty
+          clean: path/to/clean.gz
         ```
         """
         return {
-            os.path.basename(filepath): Dataset(os.path.basename(filepath), [os.path.join(basepath, filepath)])
-            for filepath in ymldata['datasets']
+            name: Dataset(name, [os.path.join(basepath, filepath)])
+            for name, filepath in ymldata['datasets'].items()
         }
 
     def _load_stage_order(self, ymldata:dict) -> List[str]:
@@ -385,41 +384,6 @@ class CurriculumV1Loader:
     def _load_modifiers(self, ymldata:dict) -> List[Modifier]:
         """Reads
         ```yml
-        uppercase: 0.05
-        titlecase: 0.05
-        ```
-        """
-        return [
-            Modifier(name, float(ymldata[name]))
-            for name in MODIFIERS.keys()
-            if name in ymldata
-        ]
-
-
-class CurriculumV2Loader(CurriculumV1Loader):
-    """Slightly different curriculum format that can have multiple files per
-    dataset, and puts the modifiers in their own section."""
-
-    def _load_datasets(self, ymldata:dict, basepath:str) -> Dict[str,Dataset]:
-        """Reads
-        ```yml
-        datasets:
-          clean:
-            - a.gz
-            - b.gz
-        ```
-        """
-        return {
-            name: Dataset(name, [
-                os.path.join(basepath, filepath)
-                for filepath in files
-            ])
-            for name, files in ymldata['datasets'].items()
-        }
-
-    def _load_modifiers(self, ymldata:dict) -> List[Modifier]:
-        """Reads
-        ```yml
         modifiers:
           - uppercase 0.05
           - titlecase 0.05
@@ -442,7 +406,6 @@ class CurriculumLoader:
 
     IMPLEMENTATIONS={
         '1': CurriculumV1Loader,
-        '2': CurriculumV2Loader,
     }
 
     def load(self, fh:Union[TextIO,str,dict], **kwargs) -> Curriculum:

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -636,6 +636,12 @@ if __name__ == '__main__':
 
     curriculum = CurriculumLoader().load(config, basepath=os.path.dirname(args.config))
 
+    # Quick cheap check that all files exist before we begin training
+    for dataset in curriculum.datasets.values():
+        missing_files = {file for file in dataset.files if not os.path.exist(file)}
+        if missing_files:
+            raise ValueError(f"Dataset '{dataset.name}' is missing files: {missing_files}")
+
     trainer = Trainer(curriculum, reader=DatasetReader if args.sync else AsyncDatasetReader, flip=args.flip, tmpdir=args.temporary_directory)
 
     state_tracker = StateTracker(args.state or f'{args.config}.state', restore=not args.do_not_resume)

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -223,14 +223,6 @@ class AsyncDatasetReader(DatasetReader):
         # Open temporary file which will contain shuffled version of `cat self.files`
         fh = TemporaryFile(mode='w+', encoding='utf-8', dir=self.tmpdir)
 
-        options = []
-
-        # See DatasetReader for notes on this
-        options += []
-
-        if self.tmpdir:
-            options += 
-
         self._pending = ShuffledFile(
             seed=seed,
             file=cast(TextIO, fh),

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -415,7 +415,7 @@ class CurriculumV2Loader(CurriculumV1Loader):
                 os.path.join(basepath, filepath)
                 for filepath in files
             ])
-            for name, files in ymldata['datasets']
+            for name, files in ymldata['datasets'].items()
         }
 
     def _load_modifiers(self, ymldata:dict) -> List[Modifier]:
@@ -627,7 +627,7 @@ if __name__ == '__main__':
     parser.add_argument("--temporary-directory", '-T', default=None, type=str, help='Temporary dir, used for shuffling and tracking state')
     parser.add_argument("--do-not-resume", '-d', action="store_true", help='Do not resume from the previous training state')
     parser.add_argument("--flip", action="store_true", help="Flip source and target sides of sentence pairs.")
-    parser.add_argument("trainer", type=str, nargs="*", help="Trainer program that gets fed the input. If empty it is read from config.")
+    parser.add_argument("trainer", type=str, nargs=argparse.REMAINDER, help="Trainer program that gets fed the input. If empty it is read from config.")
     
     args = parser.parse_args()
 

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -573,6 +573,7 @@ if __name__ == '__main__':
     # parser.add_argument("--temporary-dir", '-t', default="./TMP", type=str, help='Temporary dir, used for shuffling and tracking state')
     parser.add_argument("--do-not-resume", '-d', action="store_true", help='Do not resume from the previous training state')
     parser.add_argument("--flip", action="store_true", help="Flip source and target sides of sentence pairs.")
+    parser.add_argument("trainer", type=str, nargs="*", help="Trainer program that gets fed the input. If empty it is read from config.")
     
     args = parser.parse_args()
 
@@ -590,7 +591,7 @@ if __name__ == '__main__':
         state_harness._restore = lambda trainer: None
 
     model_trainer = subprocess.Popen(
-        config['trainer'],
+        args.trainer or config['trainer'],
         stdin=subprocess.PIPE,
         encoding="utf-8",
         preexec_fn=ignore_sigint) # ignore_sigint makes marian ignore Ctrl-C. We'll stop it from here.

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -373,13 +373,13 @@ class CurriculumV1Loader:
             dataset_name, weight = line.split()
             datasets.append((available_datasets[dataset_name], float(weight)))
 
-        _, dataset_name, max_epochs = ymldata[stage_name][-1].split()
-        assert dataset_name in available_datasets, f"until clause of stage '{stage_name}' refers to unknown dataset '{dataset_name}'"
-        assert dataset_name in {dataset.name for dataset, weight in datasets if weight > 0.0}, f"until clause of stage '{stage_name}' watches dataset '{dataset_name}' but that dataset is not read during this stage"
+        _, until_dataset_name, max_epochs = ymldata[stage_name][-1].split()
+        assert until_dataset_name in available_datasets, f"until clause of stage '{stage_name}' refers to unknown dataset '{until_dataset_name}'"
+        assert until_dataset_name in {dataset.name for dataset, weight in datasets if weight > 0.0}, f"until clause of stage '{stage_name}' watches dataset '{until_dataset_name}' but that dataset is not read during this stage"
         return Stage(
             name=stage_name,
             datasets=datasets,
-            until_dataset=dataset_name,
+            until_dataset=until_dataset_name,
             until_epoch=int(max_epochs) if max_epochs != 'inf' else None
         )
 

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -215,6 +215,13 @@ class AsyncDatasetReader(DatasetReader):
         # Start shuffling next
         self._open_async(self.seed + 1)
 
+    def restore(self, state:DatasetState) -> 'AsyncDatasetReader':
+        # Kill any advance work we did because it is likely wrong.
+        if self._pending:
+            self._pending.proc.kill()
+            self._pending = None
+        return cast('AsyncDatasetReader', super().restore(state))
+
 
 class StateLoader:
     """Tool to read and write TrainerState objects to yaml. Uses unsafe yaml

--- a/trainer/trainer.py
+++ b/trainer/trainer.py
@@ -677,7 +677,7 @@ if __name__ == '__main__':
         for batch in state_tracker.run(trainer):
             model_trainer.stdin.writelines(batch)
     except KeyboardInterrupt:
-        print("[Trainer] Ctrl-c pressed, stopping training. Press ctrl-c again to force-quit trainer")
+        print("[Trainer] Ctrl-c pressed, stopping training. Press ctrl-c again to terminate trainer")
     finally:
         try:
             model_trainer.stdin.close()

--- a/trainer/trainer_test.py
+++ b/trainer/trainer_test.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+import sys
+with open('/tmp/test', 'w', encoding='utf-8') as outfile:
+    for line in sys.stdin:
+        outfile.write(line)
+        outfile.flush()

--- a/trainer/trainer_test.yml
+++ b/trainer/trainer_test.yml
@@ -1,0 +1,33 @@
+# Datasets are already TSV files
+datasets:
+  - test/data/clean
+  - test/data/medium
+  - test/data/dirty
+
+stages:
+  - start
+  - mid
+  - end
+
+start:
+  - clean 0.8
+  - medium 0.2
+  - dirty 0
+  - until clean 2 # Until two epochs of clean
+
+mid:
+  - clean 0.6
+  - medium 0.3
+  - dirty 0.1
+  - until medium 1
+
+end:
+  - clean 0.4
+  - medium 0.3
+  - dirty 0.3
+  - until dirty 5 # use `inf` to mean until forever
+
+uppercase: 0.05
+titlecase: 0.05
+seed: 1111
+trainer: ./trainer_test.py


### PR DESCRIPTION
Restructured the trainer codebase a bit to be less stateful, more functional, better typed, and even added some unit tests. Also implemented async shuffling.

Don't try to read the diff. Just go to trainer.py, scroll all the way to the `__name__ == "__main__"` section, and start from there. It will make much more sense from there.

Todo:
- [x] maybe implement alternative to `shuffle.sh` that doesn't shuffle in memory. For speed that should be C++, but for portability it would be nice to have it in Python inside this project as well.